### PR TITLE
Adding Style Guide checks

### DIFF
--- a/src/checks/trigger-has-unique-ids.js
+++ b/src/checks/trigger-has-unique-ids.js
@@ -25,7 +25,7 @@ const triggerHasUniqueIds = {
     if (doubleId !== undefined) {
       //const repr = _.truncate(JSON.stringify(missingIdResult), 50);
       return [
-        `Got a two or more results with the id of ${doubleId}`
+        `Got two or more results with the id of ${doubleId}`
       ];
     }
     return [];

--- a/src/checks/trigger-is-object.js
+++ b/src/checks/trigger-is-object.js
@@ -15,14 +15,14 @@ const triggerIsObject = {
       return []; // trigger-is-array check will catch if not array
     }
 
-    const missingIdResult = _.find(results, (result) => {
+    const nonObjectResult = _.find(results, (result) => {
       return !_.isObject(result);
     });
 
-    if (missingIdResult) {
-      const repr = _.truncate(JSON.stringify(missingIdResult), 50);
+    if (nonObjectResult !== undefined) {
+      const repr = _.truncate(JSON.stringify(nonObjectResult), 50);
       return [
-        `Got a result missing that was not an object (${repr})`
+        `Got a result that was not an object (${repr})`
       ];
     }
     return [];

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const cleaner = require('./cleaner');
 const dataTools = require('./data');
 const zapierSchema = require('zapier-platform-schema');
+const styleGuideChecker = require('./style-guide-checker');
 
 // Take a resource list/hook and turn it into triggers, etc.
 const convertResourceDos = (appRaw) => {
@@ -74,6 +75,14 @@ const serializeApp = (compiledApp) => {
 const validateApp = (compiledApp) => {
   const cleanedApp = cleaner.recurseCleanFuncs(compiledApp);
   const results = zapierSchema.validateAppDefinition(cleanedApp);
+
+  // Check for style guide only if there are no schema errors
+  if (results.errors.length === 0) {
+    // These aren't ValidationError so it won't "stop" validation, but it will show them in `zapier validate`
+    const styleGuideResults = styleGuideChecker.validateAppDefinition(cleanedApp);
+    return dataTools.jsonCopy(styleGuideResults.errors);
+  }
+
   return dataTools.jsonCopy(results.errors);
 };
 

--- a/src/tools/style-guide-checker.js
+++ b/src/tools/style-guide-checker.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const _ = require('lodash');
+
+const buildError = (message, property) => {
+  return { message, property: `App.${property}` };
+};
+
+const isTitleCase = (label) => {
+  // TODO: Make this more strict
+  return (label[0] === label[0].toUpperCase());
+};
+
+const checkForBadLabelsIn = (type, app, errors) => {
+  // Check for "bad" labels
+  const keysWithBadLabels = _.keys(app[type]).filter((key) => {
+    return !isTitleCase(app[type][key].display.label);
+  });
+
+  if (keysWithBadLabels) {
+    keysWithBadLabels.forEach((key) => {
+      errors.push(buildError(`Labels should be TitleCase. Found "${app[type][key].display.label}".`, `${type}.${key}.display.label`));
+    });
+  }
+};
+
+const checkForSampleDataIn = (type, app, errors) => {
+  // Check Sample data exists
+  const keysWithoutSampleData = _.keys(app[type]).filter((key) => {
+    return !_.isObject(app[type][key].operation.sample);
+  });
+
+  if (keysWithoutSampleData) {
+    const capitalizedType = type[0].toUpperCase() + type.substr(1);
+
+    keysWithoutSampleData.forEach((key) => {
+      errors.push(buildError(`${capitalizedType} should always have sample data.`, `${type}.${key}.operation.sample`));
+    });
+  }
+};
+
+// Check for common style guide issues
+const validateAppDefinition = (app) => {
+  const errors = [];
+
+  // Check for "bad" labels
+  checkForBadLabelsIn('triggers', app, errors);
+  checkForBadLabelsIn('searches', app, errors);
+  checkForBadLabelsIn('creates', app, errors);
+
+  // Check for sample data
+  checkForSampleDataIn('triggers', app, errors);
+  checkForSampleDataIn('searches', app, errors);
+  checkForSampleDataIn('creates', app, errors);
+
+  return {
+    errors
+  };
+};
+
+module.exports = {
+  validateAppDefinition
+};

--- a/test/checks.js
+++ b/test/checks.js
@@ -1,0 +1,202 @@
+'use strict';
+
+require('should');
+
+const checks = {
+  isTrigger: require('../src/checks/is-trigger'),
+  triggerHasId: require('../src/checks/trigger-has-id'),
+  triggerHasUniqueIds: require('../src/checks/trigger-has-unique-ids'),
+  triggerIsArray: require('../src/checks/trigger-is-array'),
+  triggerIsObject: require('../src/checks/trigger-is-object'),
+};
+
+describe.only('checks', () => {
+
+  describe('isTrigger', () => {
+
+    it('should return true for a poll', () => {
+      checks.isTrigger('triggers.example.operation.perform').should.eql(true);
+    });
+
+    it('should return false for a create', () => {
+      checks.isTrigger('creates.example.operation.perform').should.eql(false);
+    });
+
+  });
+
+  describe('triggerHasId', () => {
+
+    it('should return no errors for results with id', () => {
+      const results = [
+        {
+          id: 1,
+          name: 'Something'
+        }
+      ];
+
+      const errors = checks.triggerHasId.run('does.not.matter', results);
+      errors.should.eql([]);
+    });
+
+    it('should return no errors for results with an empty id', () => {
+      const results = [
+        {
+          id: '',
+          name: 'Something'
+        }
+      ];
+
+      const errors = checks.triggerHasId.run('does.not.matter', results);
+      errors.should.eql([]);
+    });
+
+    it('should return errors for results without id', () => {
+      const results = [
+        {
+          name: 'Something'
+        }
+      ];
+
+      const errors = checks.triggerHasId.run('does.not.matter', results);
+      errors.should.be.an.Array();
+      errors.length.should.eql(1);
+
+      const error = errors[0];
+      error.should.containEql('Got a result missing the "id" property');
+    });
+
+    it('should return errors for results with a null id', () => {
+      const results = [
+        {
+          id: null,
+          name: 'Something'
+        }
+      ];
+
+      const errors = checks.triggerHasId.run('does.not.matter', results);
+      errors.should.be.an.Array();
+      errors.length.should.eql(1);
+
+      const error = errors[0];
+      error.should.containEql('Got a result missing the "id" property');
+    });
+
+  });
+
+  describe('triggerHasUniqueIds', () => {
+
+    it('should return no errors for results with unique ids', () => {
+      const results = [
+        {
+          id: 1,
+          name: 'Something'
+        },
+        {
+          id: 2,
+          name: 'Something Else'
+        }
+      ];
+
+      const errors = checks.triggerHasUniqueIds.run('does.not.matter', results);
+      errors.should.eql([]);
+    });
+
+    it('should return errors for results with duplicate ids', () => {
+      const results = [
+        {
+          id: 1,
+          name: 'Something'
+        },
+        {
+          id: 1,
+          name: 'Something Else'
+        }
+      ];
+
+      const errors = checks.triggerHasUniqueIds.run('does.not.matter', results);
+      errors.should.be.an.Array();
+      errors.length.should.eql(1);
+
+      const error = errors[0];
+      error.should.containEql('Got two or more results with the id of 1');
+    });
+
+  });
+
+  describe('triggerIsArray', () => {
+
+    it('should return no errors for results as array', () => {
+      const results = [];
+
+      const errors = checks.triggerIsArray.run('does.not.matter', results);
+      errors.should.eql([]);
+    });
+
+    it('should return errors for results as object', () => {
+      const results = {};
+
+      const errors = checks.triggerIsArray.run('does.not.matter', results);
+      errors.should.be.an.Array();
+      errors.length.should.eql(1);
+
+      const error = errors[0];
+      error.should.containEql('Results must be an array');
+    });
+
+  });
+
+  describe('triggerIsObject', () => {
+
+    it('should return no errors for results that are objects', () => {
+      const results = [
+        {
+          id: 1,
+          name: 'Something'
+        },
+        {
+          id: 2,
+          name: 'Something Else'
+        }
+      ];
+
+      const errors = checks.triggerIsObject.run('does.not.matter', results);
+      errors.should.eql([]);
+    });
+
+    it('should return errors for results that are not objects', () => {
+      const results = [
+        {
+          id: 1,
+          name: 'Something'
+        },
+        'Something Else'
+      ];
+
+      const errors = checks.triggerIsObject.run('does.not.matter', results);
+      errors.should.be.an.Array();
+      errors.length.should.eql(1);
+
+      const error = errors[0];
+      error.should.containEql('Got a result that was not an object');
+    });
+
+    it('should return errors for results that are null', () => {
+      const results = [
+        {
+          id: 1,
+          name: 'Something'
+        },
+        null
+      ];
+
+      const errors = checks.triggerIsObject.run('does.not.matter', results);
+      errors.should.be.an.Array();
+      errors.length.should.eql(1);
+
+      const error = errors[0];
+      error.should.containEql('Got a result that was not an object');
+    });
+
+  });
+
+});


### PR DESCRIPTION
These checks don't "fail" validation (on `zapier build` for example), but show up on `zapier validate`.

Also added tests for the `checks`, since we had none.

This is missing a version update, as I'm unsure if we want to make any other changes before that.