### PR TITLE
Apply performList && performGet if applicable. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 0.10.0
+
+* **BREAKING CHANGE** Removed getResourceOperation in creates/searches in favor of performGet.
+
+* Added support for `performList` in webhook triggers
+* Fixed: Now correctly copy outputFields and samples to a trigger/search/create operation that links to a resource
+
 ## 0.9.10
 
-* **BREAKING CHANGE** - the first `z.dehydrate()` and `appTester()` argument has changed - you can no longer provide shorthand string paths. Instead, you must provide the direct reference and it must be found somewhere in your final exported `App`'s tree. For example:
+* **BREAKING CHANGE** the first `z.dehydrate()` and `appTester()` argument has changed - you can no longer provide shorthand string paths. Instead, you must provide the direct reference and it must be found somewhere in your final exported `App`'s tree. For example:
   * `z.dehydrate('someFunction')` must be `z.dehydrate(App.hydrators.someFunction)`
   * `appTester('contact.list')` must be `appTester(App.resources.contact.list.operation.perform)`
 

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -130,7 +130,6 @@ const prepareApp = (appRaw) => {
 module.exports = {
   compileApp,
   validateApp,
-  convertResourceDos,
   serializeApp,
   prepareApp
 };

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -20,7 +20,7 @@ const convertResourceDos = (appRaw) => {
       trigger.operation.type = 'hook';
       trigger.operation.outputFields = trigger.operation.outputFields || resource.outputFields;
       if (resource.list && resource.list.operation && resource.list.operation.perform) {
-        trigger.operation.performList = trigger.operation.performList || resource.list.perform;
+        trigger.operation.performList = trigger.operation.performList || resource.list.operation.perform;
       }
       triggers[trigger.key] = trigger;
     }

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -19,6 +19,9 @@ const convertResourceDos = (appRaw) => {
       trigger.operation.resource = resource.key;
       trigger.operation.type = 'hook';
       trigger.operation.outputFields = trigger.operation.outputFields || resource.outputFields;
+      if (resource.list && resource.list.operation && resource.list.perform) {
+        trigger.operation.performList = trigger.operation.performList || resource.list.perform;
+      }
       triggers[trigger.key] = trigger;
     }
 

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -13,7 +13,7 @@ const convertResourceDos = (appRaw) => {
 
   _.each(appRaw.resources, (resource) => {
     if (resource.hook && resource.hook.operation) {
-      let trigger = resource.hook;
+      let trigger = dataTools.deepCopy(resource.hook);
       trigger.key = `${resource.key}Hook`;
       trigger.noun = resource.noun;
       trigger.operation.resource = resource.key;

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -16,10 +16,6 @@ const convertResourceDos = (appRaw) => {
       trigger.noun = resource.noun;
       trigger.operation.resource = resource.key;
       trigger.operation.type = 'hook';
-      trigger.operation.outputFields = trigger.operation.outputFields || resource.outputFields;
-      if (resource.list && resource.list.operation && resource.list.operation.perform) {
-        trigger.operation.performList = trigger.operation.performList || resource.list.operation.perform;
-      }
       triggers[trigger.key] = trigger;
     }
 
@@ -29,7 +25,6 @@ const convertResourceDos = (appRaw) => {
       trigger.noun = resource.noun;
       trigger.operation.resource = resource.key;
       trigger.operation.type = 'polling';
-      trigger.operation.outputFields = trigger.operation.outputFields || resource.outputFields;
       triggers[trigger.key] = trigger;
     }
 
@@ -38,10 +33,6 @@ const convertResourceDos = (appRaw) => {
       search.key = `${resource.key}Search`;
       search.noun = resource.noun;
       search.operation.resource = resource.key;
-      if (resource.get && resource.get.operation && resource.get.operation.perform) {
-        search.operation.performGet = search.operation.performGet || resource.get.operation.perform;
-      }
-      search.operation.outputFields = search.operation.outputFields || resource.outputFields;
       searches[search.key] = search;
     }
 
@@ -50,10 +41,6 @@ const convertResourceDos = (appRaw) => {
       create.key = `${resource.key}Create`;
       create.noun = resource.noun;
       create.operation.resource = resource.key;
-      if (resource.get && resource.get.operation && resource.get.operation.perform) {
-        create.operation.performGet = create.operation.performGet || resource.get.operation.perform;
-      }
-      create.operation.outputFields = create.operation.outputFields || resource.outputFields;
       creates[create.key] = create;
     }
 
@@ -91,6 +78,10 @@ const compileApp = (appRaw) => {
   appRaw = dataTools.deepCopy(appRaw);
   const extras = convertResourceDos(appRaw);
 
+  appRaw.triggers = _.extend({}, appRaw.triggers || {}, extras.triggers);
+  appRaw.searches = _.extend({}, appRaw.searches || {}, extras.searches);
+  appRaw.creates = _.extend({}, appRaw.creates || {}, extras.creates);
+
   _.each(appRaw.triggers, (trigger) => {
     appRaw.triggers[trigger.key] = copyPropertiesFromResource('trigger', trigger, appRaw);
   });
@@ -103,9 +94,6 @@ const compileApp = (appRaw) => {
     appRaw.creates[create.key] = copyPropertiesFromResource('create', create, appRaw);
   });
 
-  appRaw.triggers = _.extend({}, appRaw.triggers || {}, extras.triggers);
-  appRaw.searches = _.extend({}, appRaw.searches || {}, extras.searches);
-  appRaw.creates = _.extend({}, appRaw.creates || {}, extras.creates);
   return appRaw;
 };
 

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -78,9 +78,9 @@ const compileApp = (appRaw) => {
   appRaw = dataTools.deepCopy(appRaw);
   const extras = convertResourceDos(appRaw);
 
-  appRaw.triggers = _.extend({}, appRaw.triggers || {}, extras.triggers);
-  appRaw.searches = _.extend({}, appRaw.searches || {}, extras.searches);
-  appRaw.creates = _.extend({}, appRaw.creates || {}, extras.creates);
+  appRaw.triggers = _.extend({}, extras.triggers, appRaw.triggers || {});
+  appRaw.searches = _.extend({}, extras.searches, appRaw.searches || {});
+  appRaw.creates = _.extend({}, extras.creates, appRaw.creates || {});
 
   _.each(appRaw.triggers, (trigger) => {
     appRaw.triggers[trigger.key] = copyPropertiesFromResource('trigger', trigger, appRaw);

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -7,8 +7,6 @@ const zapierSchema = require('zapier-platform-schema');
 
 // Take a resource with methods like list/hook and turn it into triggers, etc.
 const convertResourceDos = (appRaw) => {
-  appRaw = dataTools.deepCopy(appRaw);
-
   let triggers = {}, searches = {}, creates = {};
 
   _.each(appRaw.resources, (resource) => {
@@ -62,7 +60,7 @@ const convertResourceDos = (appRaw) => {
     // TODO: search or create?
   });
 
-  return dataTools.deepCopy({ triggers, searches, creates });
+  return { triggers, searches, creates };
 };
 
 /* When a trigger/search/create (action) links to a resource, we walk up to

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -19,7 +19,7 @@ const convertResourceDos = (appRaw) => {
       trigger.operation.resource = resource.key;
       trigger.operation.type = 'hook';
       trigger.operation.outputFields = trigger.operation.outputFields || resource.outputFields;
-      if (resource.list && resource.list.operation && resource.list.perform) {
+      if (resource.list && resource.list.operation && resource.list.operation.perform) {
         trigger.operation.performList = trigger.operation.performList || resource.list.perform;
       }
       triggers[trigger.key] = trigger;

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -40,6 +40,9 @@ const convertResourceDos = (appRaw) => {
       search.key = `${resource.key}Search`;
       search.noun = resource.noun;
       search.operation.resource = resource.key;
+      if (resource.get && resource.get.operation && resource.get.operation.perform) {
+        search.operation.performGet = search.operation.performGet || resource.get.operation.perform;
+      }
       search.operation.outputFields = search.operation.outputFields || resource.outputFields;
       searches[search.key] = search;
     }
@@ -49,6 +52,9 @@ const convertResourceDos = (appRaw) => {
       create.key = `${resource.key}Create`;
       create.noun = resource.noun;
       create.operation.resource = resource.key;
+      if (resource.get && resource.get.operation && resource.get.operation.perform) {
+        create.operation.performGet = create.operation.performGet || resource.get.operation.perform;
+      }
       create.operation.outputFields = create.operation.outputFields || resource.outputFields;
       creates[create.key] = create;
     }

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -59,11 +59,11 @@ const copyPropertiesFromResource = (type, action, appRaw) => {
     const resource = appRaw.resources[action.operation.resource];
 
     if (type === 'trigger' && action.operation.type === 'hook') {
-      if (resource.list && resource.list.operation && resource.list.operation.perform) {
+      if (_.get(resource, 'list.operation.perform')) {
         action.operation.performList = action.operation.performList || resource.list.operation.perform;
       }
     } else if (type === 'search' || type === 'create') {
-      if (resource.get && resource.get.operation && resource.get.operation.perform) {
+      if (_.get(resource, 'get.operation.perform')) {
         action.operation.performGet = action.operation.performGet || resource.get.operation.perform;
       }
     }

--- a/test/tools/schema.js
+++ b/test/tools/schema.js
@@ -28,7 +28,7 @@ describe('schema', () => {
       });
     });
 
-    it('should populate outputFields if available', () => {
+    it('should populate generated triggers/searches/creates with properties from resource', () => {
       const dummyMethod = {
         operation: {
           perform: () => {return {};}
@@ -57,8 +57,11 @@ describe('schema', () => {
       };
       const compiledApp = schema.compileApp(appRaw);
       compiledApp.triggers.fooList.operation.outputFields.should.have.length(2);
+      compiledApp.triggers.fooList.operation.sample.should.have.keys('id', 'name');
       compiledApp.searches.fooSearch.operation.outputFields.should.have.length(2);
+      compiledApp.searches.fooSearch.operation.sample.should.have.keys('id', 'name');
       compiledApp.creates.fooCreate.operation.outputFields.should.have.length(2);
+      compiledApp.creates.fooCreate.operation.sample.should.have.keys('id', 'name');
     });
 
     it("should populate hook's performList from list method if available", () => {

--- a/test/tools/schema.js
+++ b/test/tools/schema.js
@@ -6,7 +6,7 @@ const schema = require('../../src/tools/schema');
 
 describe('schema', () => {
 
-  describe('convertResourceDos', () => {
+  describe('compileApp on a resource', () => {
     it('should handle blank methods', () => {
       const appRaw = {
         resources: {
@@ -20,12 +20,259 @@ describe('schema', () => {
           }
         }
       };
-      const obj = schema.convertResourceDos(appRaw);
-      obj.should.eql({
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.should.containEql({
         triggers: {},
         creates: {},
         searches: {}
       });
+    });
+
+    it('should populate outputFields if available', () => {
+      const dummyMethod = {
+        operation: {
+          perform: () => {return {};}
+        }
+      };
+
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            hook: dummyMethod,
+            list: dummyMethod,
+            search: dummyMethod,
+            create: dummyMethod,
+            outputFields: [
+              {key: 'id', type: 'integer'},
+              {key: 'name', type: 'string'},
+            ],
+            sample: {
+              id: 123,
+              name: 'John Doe'
+            }
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.triggers.fooList.operation.outputFields.should.have.length(2);
+      compiledApp.searches.fooSearch.operation.outputFields.should.have.length(2);
+      compiledApp.creates.fooCreate.operation.outputFields.should.have.length(2);
+    });
+
+    it("should populate hook's performList from list method if available", () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            hook: {
+              display: {},
+              operation: {},
+            },
+            list: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items'}
+              },
+            },
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.triggers.fooHook.operation.should.containEql({
+        performList: {url: 'http://local.dev/items'}
+      });
+    });
+
+    it("should not overwrite hook's existing performList with list method", () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            hook: {
+              display: {},
+              operation: {
+                performList: {url: 'http://local.dev/items-for-hook'}
+              },
+            },
+            list: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items'}
+              },
+            },
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.triggers.fooHook.operation.should.containEql({
+        performList: {url: 'http://local.dev/items-for-hook'}
+      });
+    });
+
+    it("should populate search's performGet from get method if available", () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            get: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items/{{bundle.inputData.id}}'},
+              }
+            },
+            search: {
+              display: {},
+              operation: {},
+            },
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.searches.fooSearch.operation.should.containEql({
+        performGet: {url: 'http://local.dev/items/{{bundle.inputData.id}}'}
+      });
+    });
+
+    it("should not overwrite search's existing performGet with get method", () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            get: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items/{{bundle.inputData.id}}'},
+              },
+            },
+            search: {
+              display: {},
+              operation: {
+                performGet: {url: 'http://local.dev/items-for-search/{{bundle.inputData.id}}'}
+              },
+            },
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.searches.fooSearch.operation.should.containEql({
+        performGet: {url: 'http://local.dev/items-for-search/{{bundle.inputData.id}}'}
+      });
+    });
+  });
+
+  describe('compileApp', () => {
+    it('should populate hook trigger performList when resource is linked', () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            list: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items'}
+              },
+            },
+          }
+        },
+        triggers: {
+          fastFoo: {
+            key: 'fastFoo',
+            noun: 'Foo',
+            display: {},
+            operation: {
+              resource: 'foo',
+              type: 'hook',
+            }
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.triggers.fastFoo.operation.should.containEql({
+        performList: {url: 'http://local.dev/items'}
+      });
+    });
+
+    it('should populate search with properties from linked resource', () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            get: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items/{{bundle.inputData.id}}'},
+              }
+            },
+            outputFields: [
+              {'key': 'id'},
+              {'key': 'name'}
+            ],
+            sample: {
+              'id': 123,
+              'name': 'John Doe'
+            }
+          }
+        },
+        searches: {
+          findFoo: {
+            display: {},
+            operation: {
+              resource: 'foo',
+            },
+          },
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.searches.findFoo.operation.should.containEql({
+        performGet: {url: 'http://local.dev/items/{{bundle.inputData.id}}'}
+      });
+      compiledApp.searches.findFoo.operation.outputFields.should.have.length(2);
+      compiledApp.searches.findFoo.operation.sample.should.have.keys('id', 'name');
+    });
+
+    it('should populate create with properties from linked resource', () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            get: {
+              display: {},
+              operation: {
+                perform: {url: 'http://local.dev/items/{{bundle.inputData.id}}'},
+              }
+            },
+            outputFields: [
+              {'key': 'id'},
+              {'key': 'name'}
+            ],
+            sample: {
+              'id': 123,
+              'name': 'John Doe'
+            }
+          }
+        },
+        creates: {
+          makeFoo: {
+            display: {},
+            operation: {
+              resource: 'foo',
+            },
+          },
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.creates.makeFoo.operation.should.containEql({
+        performGet: {url: 'http://local.dev/items/{{bundle.inputData.id}}'}
+      });
+      compiledApp.creates.makeFoo.operation.outputFields.should.have.length(2);
+      compiledApp.creates.makeFoo.operation.sample.should.have.keys('id', 'name');
     });
   });
 });


### PR DESCRIPTION
I like this but I'm not 100% sold on this - let's chat about this @bcooksey. The alternative is that the backend introspects across resources and triggers instead of having it right there.