### PR TITLE
use dotenv for fileparsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bluebird": "3.4.6",
     "content-disposition": "0.5.1",
-    "dotenv": "^2.0.0",
+    "dotenv": "4.0.0",
     "form-data": "1.0.0",
     "lodash": "4.15.0",
     "node-fetch": "1.6.2",
@@ -43,7 +43,7 @@
     "estraverse-fb": "1.3.1",
     "marked-toc": "0.3.0",
     "mocha": "3.0.2",
-    "mock-fs": "^3.12.1",
+    "mock-fs": "4.1.0",
     "nock": "8.0.0",
     "should": "11.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "bluebird": "3.4.6",
     "content-disposition": "0.5.1",
+    "dotenv": "^2.0.0",
     "form-data": "1.0.0",
     "lodash": "4.15.0",
     "node-fetch": "1.6.2",
@@ -42,6 +43,7 @@
     "estraverse-fb": "1.3.1",
     "marked-toc": "0.3.0",
     "mocha": "3.0.2",
+    "mock-fs": "^3.12.1",
     "nock": "8.0.0",
     "should": "11.1.0"
   }

--- a/src/tools/environment.js
+++ b/src/tools/environment.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const _ = require('lodash');
-const fs = require('fs');
 const path = require('path');
+const dotenv = require('dotenv');
 
 const ensurePath = require('./ensure-path');
 
@@ -28,24 +28,10 @@ const cleanEnvironment = () => {
   }
 };
 
-const readEnvironmentFile = () => {
-  const data = {};
-  try {
-    const content = fs.readFileSync(path.join(process.cwd(), '.environment'));
-    _.split(content, '\n').map(line => {
-      const parts = _.split(line, '=');
-      const key = parts.shift();
-      const value = parts.join('=');
-      data[key] = value;
-    });
-    return data;
-  } catch(err) {
-    return data;
-  }
-};
-
-const injectEnvironmentFile = () => {
-  _.extend(process.env, readEnvironmentFile());
+const injectEnvironmentFile = (filename) => {
+  filename = filename || '.environment';
+  const filepath = path.join(process.cwd(), filename);
+  dotenv.load({path: filepath});
 };
 
 module.exports = {

--- a/test/tools/environment.js
+++ b/test/tools/environment.js
@@ -1,0 +1,32 @@
+require('should');
+const mock = require('mock-fs');
+
+const tools = require('../../src/tools/exported');
+const fake_file = 'CITY="boulder"\nNAME="david"\nPIZZA="Blackjack"\n';
+
+describe('read env', () => {
+  beforeEach(() => {
+    mock({
+      '.environment': fake_file,
+      'secrets': 'SECRET=very_secret_thing'
+    });
+  });
+
+  it('should parse a config', (done) => {
+    tools.env.inject();
+    process.env.PIZZA.should.equal('Blackjack');
+    done();
+  });
+
+  it('should parse a with filename', (done) => {
+    tools.env.inject('secrets');
+    process.env.SECRET.should.equal('very_secret_thing');
+    done();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+});
+
+


### PR DESCRIPTION
Switch to the flexible and well-loved [dotenv](https://github.com/motdotla/dotenv) for parsing `.environment` files. This has the bonus side effect of letting us specify other filenames (such as the fairly common `.env`). 