### PR TITLE
Enable devs to write local tests against production RPC API

### DIFF
--- a/src/tools/create-rpc-client.js
+++ b/src/tools/create-rpc-client.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 
+const constants = require('../constants');
 const request = require('./request-client-internal');
 
 const FALLBACK_RPC = process.env.ZAPIER_BASE_ENDPOINT + '/platform/rpc/cli';
@@ -30,7 +31,14 @@ const createRpcClient = (event) => {
     } else if (process.env.ZAPIER_DEPLOY_KEY) {
       req.headers['X-Deploy-Key'] = process.env.ZAPIER_DEPLOY_KEY;
     } else {
-      throw new Error('No token or deploy key found - cannot call RPC');
+      if (constants.IS_TESTING) {
+        throw new Error(
+          'No deploy key found. Make sure you set the `ZAPIER_DEPLOY_KEY` environment variable ' +
+          'to write tests that rely on the RPC API (i.e. z.stashFile)'
+        );
+      } else {
+        throw new Error('No token found - cannot call RPC');
+      }
     }
 
     return request(req)

--- a/src/tools/create-rpc-client.js
+++ b/src/tools/create-rpc-client.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const request = require('./request-client-internal');
 
-const FALLBACK_RPC = 'http://localhost:8000/platform/rpc/cli';
+const FALLBACK_RPC = process.env.ZAPIER_BASE_ENDPOINT + '/platform/rpc/cli';
 
 const createRpcClient = (event) => {
   return function(method) {
@@ -17,10 +17,6 @@ const createRpcClient = (event) => {
       method,
       params
     });
-
-    // if (event.rpc_base) {
-    //   throw new Error('No `event.rpc_base` provided - cannot call RPC');
-    // }
 
     const req = {
       method: 'POST',


### PR DESCRIPTION
For https://github.com/zapier/zapier-platform-core/issues/14. This is taking the second option of the listed approaches and opening up the production RPC for local testing.

Long term, the local stashing may be interesting, but this will do in the interim.