### PR TITLE
Support streamed non-ascii files in z.stashFile

### DIFF
--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -88,4 +88,19 @@ describe('file upload', () => {
       .catch(done);
   });
 
+  it('should upload a resolved buffer', (done) => {
+    mocky.mockRpcCall(mocky.fakeSignedPostData);
+    mocky.mockUpload();
+
+    const file = Promise.resolve()
+      .then(() => new Buffer('7468697320697320612074c3a97374', 'hex'));
+
+    stashFile(file)
+      .then((url) => {
+        should(url).eql(`${mocky.fakeSignedPostData.url}${mocky.fakeSignedPostData.fields.key}`);
+        done();
+      })
+      .catch(done);
+  });
+
 });


### PR DESCRIPTION
Solves [this problem](https://zapier-platform.slack.com/archives/C2S5DGF6G/p1489610122403555).