### PR TITLE
Add checks for searches

### DIFF
--- a/src/app-middlewares/after/checks.js
+++ b/src/app-middlewares/after/checks.js
@@ -5,13 +5,7 @@ const _ = require('lodash');
 const constants = require('../../constants');
 const errors = require('../../errors');
 
-const checks = [
-  require('../../checks/trigger-is-array'),
-  require('../../checks/trigger-is-object'),
-  require('../../checks/trigger-has-id'),
-  require('../../checks/trigger-has-unique-ids'),
-  require('../../checks/create-is-single')
-];
+const checks = _.values(require('../../checks'));
 
 /*
   Take a look at our output results, run some checks on it, and depending on if we

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  createIsSingle: require('./create-is-single'),
+
+  searchIsArray: require('./search-is-array'),
+
+  triggerIsArray: require('./trigger-is-array'),
+  triggerIsObject: require('./trigger-is-object'),
+  triggerHasUniqueIds: require('./trigger-has-unique-ids'),
+  triggerHasId: require('./trigger-has-Id')
+};

--- a/src/checks/index.js
+++ b/src/checks/index.js
@@ -6,5 +6,5 @@ module.exports = {
   triggerIsArray: require('./trigger-is-array'),
   triggerIsObject: require('./trigger-is-object'),
   triggerHasUniqueIds: require('./trigger-has-unique-ids'),
-  triggerHasId: require('./trigger-has-Id')
+  triggerHasId: require('./trigger-has-id')
 };

--- a/src/checks/is-search.js
+++ b/src/checks/is-search.js
@@ -1,0 +1,6 @@
+module.exports = (method) => {
+  return (
+    (method.startsWith('searches.') && method.endsWith('.operation.perform')) ||
+    (method.startsWith('resources.') && method.endsWith('.search.operation.perform'))
+  );
+};

--- a/src/checks/search-is-array.js
+++ b/src/checks/search-is-array.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const _ = require('lodash');
+
+const isSearch = require('./is-search');
+
+/*
+  Searches should always return an array of objects.
+*/
+const searchIsArray = {
+  name: 'triggerIsArray',
+  shouldRun: isSearch,
+  run: (method, results) => {
+    if (!_.isArray(results)) {
+      const repr = _.truncate(JSON.stringify(results), 50);
+      return [
+        `Results must be an array, got: ${typeof results}, (${repr})`
+      ];
+    }
+    return [];
+  }
+};
+
+module.exports = searchIsArray;

--- a/src/checks/trigger-is-object.js
+++ b/src/checks/trigger-is-object.js
@@ -15,12 +15,12 @@ const triggerIsObject = {
       return []; // trigger-is-array check will catch if not array
     }
 
-    const missingIdResult = _.find(results, (result) => {
-      return !_.isObject(result);
+    const nonObjectResult = _.find(results, (result) => {
+      return !_.isPlainObject(result);
     });
 
-    if (missingIdResult) {
-      const repr = _.truncate(JSON.stringify(missingIdResult), 50);
+    if (nonObjectResult !== undefined) {
+      const repr = _.truncate(JSON.stringify(nonObjectResult), 50);
       return [
         `Got a result missing that was not an object (${repr})`
       ];

--- a/test/checks.js
+++ b/test/checks.js
@@ -2,14 +2,19 @@
 
 require('should');
 
-const createIsSingle = require('../src/checks/create-is-single');
+const checks = require('../src/checks');
 
 describe('checks', () => {
   it('createIsSingle sees create return values with multiples', () => {
-    createIsSingle.run('some.method', []).length.should.eql(0);
-    createIsSingle.run('some.method', [{}]).length.should.eql(0);
-    createIsSingle.run('some.method', {}).length.should.eql(0);
-    // the only error in this set:
-    createIsSingle.run('some.method', [{}, {}]).length.should.eql(1);
+    checks.createIsSingle.run('some.method', []).length.should.eql(0);
+    checks.createIsSingle.run('some.method', [{}]).length.should.eql(0);
+    checks.createIsSingle.run('some.method', {}).length.should.eql(0);
+
+    checks.createIsSingle.run('some.method', [{}, {}]).length.should.eql(1);
+  });
+
+  it('searchIsArray should error for objects', () => {
+    checks.searchIsArray.run('some.method', [{}, {}]).length.should.eql(0);
+    checks.searchIsArray.run('some.method', {}).length.should.eql(1);
   });
 });

--- a/test/checks.js
+++ b/test/checks.js
@@ -4,17 +4,65 @@ require('should');
 
 const checks = require('../src/checks');
 
-describe('checks', () => {
-  it('createIsSingle sees create return values with multiples', () => {
-    checks.createIsSingle.run('some.method', []).length.should.eql(0);
-    checks.createIsSingle.run('some.method', [{}]).length.should.eql(0);
-    checks.createIsSingle.run('some.method', {}).length.should.eql(0);
+const isTrigger = require('../src/checks/is-trigger');
+const isSearch = require('../src/checks/is-search');
+const isCreate = require('../src/checks/is-create');
 
-    checks.createIsSingle.run('some.method', [{}, {}]).length.should.eql(1);
+const testMethod = 'some.method';
+
+describe('checks', () => {
+  it('should see create return values with multiples via createIsSingle', () => {
+    checks.createIsSingle.run(testMethod, []).length.should.eql(0);
+    checks.createIsSingle.run(testMethod, [{}]).length.should.eql(0);
+    checks.createIsSingle.run(testMethod, {}).length.should.eql(0);
+
+    checks.createIsSingle.run(testMethod, [{}, {}]).length.should.eql(1);
   });
 
-  it('searchIsArray should error for objects', () => {
-    checks.searchIsArray.run('some.method', [{}, {}]).length.should.eql(0);
-    checks.searchIsArray.run('some.method', {}).length.should.eql(1);
+  it('should error for objects via searchIsArray', () => {
+    checks.searchIsArray.run(testMethod, [{}, {}]).length.should.eql(0);
+    checks.searchIsArray.run(testMethod, [{}]).length.should.eql(0);
+    checks.searchIsArray.run(testMethod, {}).length.should.eql(1);
+  });
+
+  it('should check for ids via triggerHasId', () => {
+    checks.triggerHasId.run(testMethod, [{id: 1}]).length.should.eql(0);
+    checks.triggerHasId.run(testMethod, [{id: 1}, {id: 2}]).length.should.eql(0);
+    checks.triggerHasId.run(testMethod, [{game_id: 1}]).length.should.eql(1);
+    checks.triggerHasId.run(testMethod, []).length.should.eql(0, 'blank array');
+  });
+
+  it('should check for unique ids via triggerHasUniqueIds', () => {
+    checks.triggerHasUniqueIds.run(testMethod, [{ id: 1 }, { id: 2 }]).length.should.eql(0);
+    checks.triggerHasUniqueIds.run(testMethod, [{ id: 1 }, { id: 1 }]).length.should.eql(1);
+
+    checks.triggerHasUniqueIds.run(testMethod, []).length.should.eql(0);
+  });
+
+  it('should error for objects via triggerIsArray', () => {
+    checks.triggerIsArray.run(testMethod, [{}, {}]).length.should.eql(0);
+    checks.triggerIsArray.run(testMethod, []).length.should.eql(0);
+    checks.triggerIsArray.run(testMethod, {}).length.should.eql(1);
+  });
+
+  it('should error for non-objects via triggerIsObject', () => {
+    checks.triggerIsObject.run(testMethod, ['']).length.should.eql(1, 'empty string');
+    checks.triggerIsObject.run(testMethod, []).length.should.eql(0, 'empty array');
+    checks.triggerIsObject.run(testMethod, [{}, {}]).length.should.eql(0, 'single object');
+    checks.triggerIsObject.run(testMethod, [{}, []]).length.should.eql(1, 'mismatched objects');
+  });
+
+  it('should recognize types by name', () => {
+    isTrigger('triggers.blah.operation.perform').should.be.true();
+    isTrigger('resources.blah.list.operation.perform').should.be.true();
+    isTrigger('blah').should.be.false();
+
+    isSearch('searches.blah.operation.perform').should.be.true();
+    isSearch('resources.blah.search.operation.perform').should.be.true();
+    isSearch('blah').should.be.false();
+
+    isCreate('creates.blah.operation.perform').should.be.true();
+    isCreate('resources.blah.create.operation.perform').should.be.true();
+    isCreate('blah').should.be.false();
   });
 });


### PR DESCRIPTION
Ensure that they return an array (of any length). Relates to https://github.com/zapier/zapier/issues/11924. 

Once merged, I'll do a `patch` release (this shouldn't break existing code, because before today searches that returned objects would have seen an error on the server) and bump cli. 