### PR TITLE
Improving ID checks

### DIFF
--- a/src/app-middlewares/after/checks.js
+++ b/src/app-middlewares/after/checks.js
@@ -25,7 +25,7 @@ const checkOutput = (output) => {
   if (runChecks) {
     const rawResults = checks
       .filter((check) => {
-        return check.shouldRun(event.method);
+        return check.shouldRun(event.method, event.bundle);
       })
       .map((check) => {
         return check.run(event.method, output.results)

--- a/src/checks/example.js
+++ b/src/checks/example.js
@@ -8,7 +8,7 @@
 */
 const exampleChecker = {
   name: 'exampleChecker',
-  shouldRun: (method) => {
+  shouldRun: (method/*, bundle*/) => {
     return method && true;
   },
   run: (method, results) => {

--- a/src/checks/trigger-has-id.js
+++ b/src/checks/trigger-has-id.js
@@ -9,10 +9,13 @@ const isTrigger = require('./is-trigger');
 */
 const triggerHasId = {
   name: 'triggerHasId',
-  shouldRun: isTrigger,
+  shouldRun: (method, bundle) => {
+    // Hooks will have a bundle.cleanedRequest and we don't need to check they've got an id
+    return (isTrigger(method) && bundle.cleanedRequest);
+  },
   run: (method, results) => {
     const missingIdResult = _.find(results, (result) => {
-      return _.isUndefined(result.id) || _.isNull(result.id);
+      return !result || _.isUndefined(result.id) || _.isNull(result.id);
     });
 
     if (missingIdResult) {

--- a/src/checks/trigger-has-id.js
+++ b/src/checks/trigger-has-id.js
@@ -11,7 +11,7 @@ const triggerHasId = {
   name: 'triggerHasId',
   shouldRun: (method, bundle) => {
     // Hooks will have a bundle.cleanedRequest and we don't need to check they've got an id
-    return (isTrigger(method) && bundle.cleanedRequest);
+    return (isTrigger(method) && !bundle.cleanedRequest);
   },
   run: (method, results) => {
     const missingIdResult = _.find(results, (result) => {

--- a/test/checks.js
+++ b/test/checks.js
@@ -30,6 +30,9 @@ describe('checks', () => {
     checks.triggerHasId.run(testMethod, [{id: 1}, {id: 2}]).length.should.eql(0);
     checks.triggerHasId.run(testMethod, [{game_id: 1}]).length.should.eql(1);
     checks.triggerHasId.run(testMethod, []).length.should.eql(0, 'blank array');
+    checks.triggerHasId.run(testMethod, [1]).length.should.eql(1);
+    checks.triggerHasId.run(testMethod, [{id: null}]).length.should.eql(1);
+    checks.triggerHasId.run(testMethod, [{}]).length.should.eql(1);
   });
 
   it('should check for unique ids via triggerHasUniqueIds', () => {


### PR DESCRIPTION
Remove check of .id property in Hooks and make it more defensive (don't throw an exception when the `result` is `null`, for example).

Fixes #25 
Fixes #32 