### PR TITLE
Allow file stashing within a create/action

### DIFF
--- a/src/tools/create-file-stasher.js
+++ b/src/tools/create-file-stasher.js
@@ -75,11 +75,10 @@ const createFileStasher = (input) => {
       return ZapierPromise.reject(new Error('rpc is not available'));
     }
 
-    const isRunningOnHydratorOrCreate = () => {
-      const whereAreWe = _.get(input, '_zapier.event.method', '');
-      return whereAreWe.indexOf('hydrators.') === 0 || whereAreWe.indexOf('creates.') === 0;
-    };
-    if (!isRunningOnHydratorOrCreate) {
+    const isRunningOnHydrator = _.get(input, '_zapier.event.method', '').indexOf('hydrators.') === 0;
+    const isRunningOnCreate = _.get(input, '_zapier.event.method', '').indexOf('creates.') === 0;
+
+    if (!isRunningOnHydrator && !isRunningOnCreate) {
       return ZapierPromise.reject(new Error('Files can only be stashed within a create or hydration function/method.'));
     }
 

--- a/src/tools/create-file-stasher.js
+++ b/src/tools/create-file-stasher.js
@@ -78,7 +78,7 @@ const createFileStasher = (input) => {
     const isRunningOnHydratorOrCreate = () => {
       const whereAreWe = _.get(input, '_zapier.event.method', '');
       return whereAreWe.indexOf('hydrators.') === 0 || whereAreWe.indexOf('creates.') === 0;
-    }
+    };
     if (!isRunningOnHydratorOrCreate) {
       return ZapierPromise.reject(new Error('Files can only be stashed within a create or hydration function/method.'));
     }

--- a/src/tools/create-file-stasher.js
+++ b/src/tools/create-file-stasher.js
@@ -75,9 +75,12 @@ const createFileStasher = (input) => {
       return ZapierPromise.reject(new Error('rpc is not available'));
     }
 
-    const isRunningOnHydrator = _.get(input, '_zapier.event.method', '').indexOf('hydrators.') === 0;
-    if (!isRunningOnHydrator) {
-      return ZapierPromise.reject(new Error('Cannot stash files outside an hydration function/method.'));
+    const isRunningOnHydratorOrCreate = () => {
+      const whereAreWe = _.get(input, '_zapier.event.method', '');
+      return whereAreWe.indexOf('hydrators.') === 0 || whereAreWe.indexOf('creates.') === 0;
+    }
+    if (!isRunningOnHydratorOrCreate) {
+      return ZapierPromise.reject(new Error('Files can only be stashed within a create or hydration function/method.'));
     }
 
     return rpc('get_presigned_upload_post_data')

--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -110,7 +110,7 @@ describe('file upload', () => {
       .catch(done);
   });
 
-  it('should fail if not being called from an hydrator event', (done) => {
+  it('should fail if being called from a trigger event', (done) => {
     const pollingStashFile = createFileStasher({
       _zapier: {
         rpc,
@@ -124,7 +124,7 @@ describe('file upload', () => {
     pollingStashFile(file)
       .then(() => done(new Error('this should have exploded')))
       .catch(err => {
-        should(err.message).containEql('Cannot stash files outside an hydration function/method');
+        should(err.message).containEql('Files can only be stashed within a create or hydration function/method');
         done();
       })
       .catch(done);


### PR DESCRIPTION
Needed for situations where an action/create receives the file's contents from the API/endpoint, and needs to stash that for use in future Zap steps.