### PR TITLE
Increase dehydrator max payload size to 2 KB

### DIFF
--- a/src/tools/create-dehydrator.js
+++ b/src/tools/create-dehydrator.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const resolveMethodPath = require('./resolve-method-path');
 
-const MAX_PAYLOAD_SIZE = 800; // most urls cannot be larger than 2,083
+const MAX_PAYLOAD_SIZE = 2048; // most urls cannot be larger than 2,083
 const wrapHydrate = (s) => `hydrate|||${JSON.stringify(s)}|||hydrate`;
 
 const createDehydrator = (input) => {

--- a/test/hydration.js
+++ b/test/hydration.js
@@ -45,6 +45,17 @@ describe('hydration', () => {
       result.should.eql('hydrate|||{"type":"method","method":"some.path.to","bundle":{}}|||hydrate');
     });
 
+    it('should not accept payload size bigger than 2048 bytes.', () => {
+      const inputData = { key: 'a'.repeat(2049) };
+      const payloadSize = JSON.stringify(inputData).length;
+      try {
+        dehydrate(funcToFind, inputData);
+        '1'.should.eql('2'); // shouldn't pass
+      } catch (err) {
+        err.message.should.containEql(`Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under 2048 bytes (usually by just passing the needed IDs).`);
+      }
+    });
+
   });
 
 });


### PR DESCRIPTION
Had to increase the dehydrator max payload size to accommodate Zap cases that didn't experience 800 bytes size limit on old Python apps.

![](https://cdn.zapier.com/storage/photos/9ccf89a29ee9812857f4841fe7c4452d.png)