### PR TITLE
Allows modules to be objects in app definitions

### DIFF
--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -2,9 +2,10 @@
 
 const _ = require('lodash');
 const memoize = require('./memoize');
+const plainModule = require('./plain');
 
 const isPlainObj = (o) => {
-  return o && typeof o == 'object' && o.constructor === Object;
+  return o && typeof o == 'object' && (o.constructor === Object || o.constructor === plainModule.constructor);
 };
 
 const comparison = (obj, needle) => obj === needle;

--- a/test/moduleuserapp/authentication.js
+++ b/test/moduleuserapp/authentication.js
@@ -1,0 +1,17 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+exports.type = 'oauth2';
+
+exports.test = () => 'test';
+
+const oauth2Config = exports.oauth2Config = {};
+
+oauth2Config.autoRefresh = true;
+
+oauth2Config.authorizeUrl = {
+  url: 'https://example.com/auth/oauth/v2/authorize',
+};

--- a/test/moduleuserapp/index.js
+++ b/test/moduleuserapp/index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+
+var _authentication = require('./authentication');
+
+function _interopRequireWildcard(obj) {
+  if (obj && obj.__esModule) {
+    return obj;
+  } else {
+    var newObj = {};
+    if (obj != null) {
+      for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          newObj[key] = obj[key];
+        }
+      }
+    }
+    newObj.default = obj; return newObj;
+  }
+}
+
+var authentication = _interopRequireWildcard(_authentication);
+
+exports.default = {
+  authentication,
+};
+
+module.exports = exports['default'];  // eslint-disable-line

--- a/test/tools/resolve-method-path.js
+++ b/test/tools/resolve-method-path.js
@@ -5,11 +5,13 @@ require('should');
 const _ = require('lodash');
 
 const appDefinition = require('../userapp');
+const moduleAppDefinition = require('../moduleuserapp');
 const resolveMethodPath = require('../../src/tools/resolve-method-path');
 const schemaTools = require('../../src/tools/schema');
 
 describe('resolve-method-path', () => {
   const app = schemaTools.prepareApp(appDefinition);
+  const moduleApp = schemaTools.prepareApp(moduleAppDefinition);
 
   const oauthAppDef = _.extend({}, appDefinition);
   oauthAppDef.authentication = {
@@ -23,6 +25,14 @@ describe('resolve-method-path', () => {
   it('should resolve a request method object with a url', () => {
     resolveMethodPath(app, app.resources.contact.list.operation.perform)
       .should.eql('resources.contact.list.operation.perform');
+  });
+
+  it('should resolve a method in a module', () => {
+    resolveMethodPath(moduleApp, moduleApp.authentication.test)
+      .should.eql('authentication.test');
+
+    resolveMethodPath(moduleApp, moduleAppDefinition.authentication.oauth2Config.authorizeUrl)
+      .should.eql('authentication.oauth2Config.authorizeUrl');
   });
 
   it('should resolve an inputFields array', () => {


### PR DESCRIPTION
I ran into an edge case where I wanted to define various portions of the app definition in modules.

E.g. authentication:

```js
// ./authentication.js
export const test = () => {};
export const oauth2Config = {};
oauth2Config.authorizeUrl = {...};
```

in index.js

```js
import * as authentication from './authentication';

export default {
     authentication,
};
```

This works out of the box, but testing was breaking due to the `isPlainObject` check. I've added a plain module with an empty index.js to grab the constructor used by the runtime. I'll add a test, but wanted to run this by the team first. 
