### PR TITLE
Use "application" discrete-type instead of "binary" as default content type.

### DIFF
--- a/src/tools/create-file-stasher.js
+++ b/src/tools/create-file-stasher.js
@@ -18,7 +18,7 @@ const LENGTH_ERR_MESSAGE = (
 );
 
 const DEFAULT_FILE_NAME = 'unnamedfile';
-const DEFAULT_CONTENT_TYPE = 'binary/octet-stream';
+const DEFAULT_CONTENT_TYPE = 'application/octet-stream';
 
 const uploader = (signedPostData, bufferStringStream, knownLength, filename, contentType) => {
   const form = new FormData();


### PR DESCRIPTION
The "binary" subtype is not standard per RFC 2045 and causes issues with services expecting "application/octet-stream" instead.

See https://tools.ietf.org/html/rfc2045#section-5.1 for more details.