### PR TITLE
Use unsafe data when logging to stdout

### DIFF
--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -86,13 +86,13 @@ const sendLog = (options, event, message, data) => {
   data.log_type = data.log_type || 'console';
 
   const sensitiveBank = makeSensitiveBank(event);
-  message = truncate(cleaner.recurseReplaceBank(message, sensitiveBank));
-  data = cleaner.recurseReplaceBank(data, sensitiveBank);
-  data = dataTools.recurseReplace(data, truncate);
+  const safeMessage = truncate(cleaner.recurseReplaceBank(message, sensitiveBank));
+  const safeData = dataTools.recurseReplace(cleaner.recurseReplaceBank(data, sensitiveBank), truncate);
+  const unsafeData = dataTools.recurseReplace(data, truncate);
 
   const body = {
-    message,
-    data,
+    message: safeMessage,
+    data: safeData,
     token: options.token,
   };
 
@@ -106,12 +106,12 @@ const sendLog = (options, event, message, data) => {
   };
 
   if (event.logToStdout) {
-    toStdout(event, body.message, data);
+    toStdout(event, message, unsafeData);
   }
 
   if (options.logBuffer && data.log_type === 'console') {
     // Cap size of messages in log buffer, in case devs log humongous things.
-    options.logBuffer.push({type: data.log_type, message: body.message});
+    options.logBuffer.push({type: safeData.log_type, message: safeMessage});
   }
 
   if (options.token) {

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -111,7 +111,7 @@ const sendLog = (options, event, message, data) => {
 
   if (options.logBuffer && data.log_type === 'console') {
     // Cap size of messages in log buffer, in case devs log humongous things.
-    options.logBuffer.push({type: data.log_type, message: truncate(body.message)});
+    options.logBuffer.push({type: data.log_type, message: body.message});
   }
 
   if (options.token) {


### PR DESCRIPTION
When running `zapier test --debug` it can be very [frustrating](https://secure.helpscout.net/conversation/442126165/677053/?folderId=20363) to have censored logs and IMHO as long as no hacker is peeking over your shoulder we should be fine logging unsafe data to the console.

I'm not sure if we can also use unsafe data for `options.logBuffer && data.log_type === 'console'` at https://github.com/zapier/zapier-platform-core/pull/50/files#diff-0936f4d83f660e8d3b1ba19e2225e4c6R114.

I'm also not sure how to best test this. Can we capture stdout in a test to verify it's unsafe?