### PR TITLE
Log http(s) requests for non-client library

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,9 @@ const RENDER_ONLY_METHODS = ['authentication.oauth2Config.authorizeUrl'];
 
 const REQUEST_OBJECT_SHORTHAND_OPTIONS = {replace: true};
 
+const DEFAULT_LOGGING_HTTP_ENDPOINT = 'https://httplogger.zapier.com/input';
+const DEFAULT_LOGGING_HTTP_API_KEY = 'R24hzu86v3jntwtX2DtYECeWAB'; // It's ok, this isn't PROD
+
 module.exports = {
   IS_TESTING,
   KILL_MIN_LIMIT,
@@ -21,5 +24,7 @@ module.exports = {
   RESPONSE_SIZE_LIMIT,
   HYDRATE_DIRECTIVE_HOIST,
   RENDER_ONLY_METHODS,
-  REQUEST_OBJECT_SHORTHAND_OPTIONS
+  REQUEST_OBJECT_SHORTHAND_OPTIONS,
+  DEFAULT_LOGGING_HTTP_ENDPOINT,
+  DEFAULT_LOGGING_HTTP_API_KEY,
 };

--- a/src/http-middlewares/after/log-response.js
+++ b/src/http-middlewares/after/log-response.js
@@ -11,7 +11,7 @@ const prepHeaders = (headers) => {
     headers = _headers;
   }
 
-  return Object.keys(headers ).map((k) => {
+  return Object.keys(headers).map((k) => {
     const v = headers[k];
     return `${k}: ${v}`;
   });
@@ -44,8 +44,9 @@ const prepareRequestLog = (req, resp) => {
     request_url: req.url,
     request_method: req.method || 'GET',
     request_headers: requestHeaders.join('\n'),
-    response_status_code: resp.status,
     request_data: req.body,
+    request_via_client: true,
+    response_status_code: resp.status,
     response_headers: respHeaders.join('\n'),
     response_content: body
   };

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -17,6 +17,7 @@ const sugarBody = (req) => {
   // move into the body as raw, set headers for coerce, merge to work
 
   req.headers = req.headers || {};
+  req.headers['user-agent'] = 'Zapier';
 
   if (!req.body && req.form) {
     req.body = req.form;

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -17,7 +17,6 @@ const sugarBody = (req) => {
   // move into the body as raw, set headers for coerce, merge to work
 
   req.headers = req.headers || {};
-  req.headers['user-agent'] = 'Zapier';
 
   if (!req.body && req.form) {
     req.body = req.form;

--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -55,8 +55,7 @@ const createHttpPatch = (event) => {
           logger(`${logData.response_status_code} ${logData.request_method} ${logData.request_url}`, logData);
         };
 
-        response.setEncoding('utf8');
-        response.on('data', (chunk) => responseBody.push(chunk));
+        response.on('data', (chunk) => responseBody.push(chunk.toString()));
         response.on('end', logResponse);
         response.on('error', logResponse);
 

--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -1,0 +1,69 @@
+const _ = require('lodash');
+const constants = require('../constants');
+
+const createHttpPatch = (event) => {
+  const createLogger = require('./create-logger');
+  const logBuffer = [];
+  const logger = createLogger(event, {logBuffer});
+
+  const httpPatch = (object) => {
+    const originalRequest = object.request;
+
+    // Proxy the request method
+    object.request = (options, callback) => {
+      const requestUrl = options.url || options.href || (`${options.protocol || 'https://'}${options.host}${options.path}`);
+      const logger_url = process.env.LOGGING_ENDPOINT || constants.DEFAULT_LOGGING_HTTP_ENDPOINT;
+
+      // Ignore logger requests
+      if (requestUrl.indexOf(logger_url) !== -1) {
+        return originalRequest(options, callback);
+      }
+
+      // Ignore requests made via the request client
+      if (_.get(options.headers, 'user-agent', []).indexOf('Zapier') !== -1) {
+        return originalRequest(options, callback);
+      }
+
+      // Proxy the callback to get the response
+      const newCallback = function(response) {
+        const requestHeaders = _.map(Object.keys(options.headers || {}), (header) => `${header}: ${options.headers[header]}`);
+        const responseHeaders = _.map(Object.keys(response.headers || {}), (header) => `${header}: ${response.headers[header]}`);
+        const responseBody = [];
+
+        const logResponse = () => {
+          // Prepare data for GL
+          const logData = {
+            log_type: 'http',
+            request_type: 'devplatform-outbound',
+            request_url: requestUrl,
+            request_method: options.method || 'GET',
+            request_headers: requestHeaders.join('\n'),
+            request_data: options.body || '',
+            request_via_client: false,
+            response_status_code: response.statusCode,
+            response_headers: responseHeaders.join('\n'),
+            response_content: responseBody.join(''),
+          };
+
+          logger(`${logData.response_status_code} ${logData.request_method} ${logData.request_url}`, logData);
+        };
+
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => responseBody.push(chunk));
+        response.on('end', logResponse);
+        response.on('error', logResponse);
+
+        // If there was a callback, call it now
+        if (_.isFunction(callback)) {
+          callback.apply(this, arguments);
+        }
+      };
+
+      return originalRequest(options, newCallback);
+    };
+  };
+
+  return httpPatch;
+};
+
+module.exports = createHttpPatch;

--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -9,6 +9,13 @@ const createHttpPatch = (event) => {
   const httpPatch = (object) => {
     const originalRequest = object.request;
 
+    // Avoids multiple patching and memory leaks (mostly when running tests locally)
+    if (object.patchedByZapier) {
+      return;
+    }
+
+    object.patchedByZapier = true;
+
     // Proxy the request method
     object.request = (options, callback) => {
       const requestUrl = options.url || options.href || (`${options.protocol || 'https://'}${options.host}${options.path}`);

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -12,6 +12,7 @@ const ZapierPromise = require('./promise');
 const environmentTools = require('./environment');
 const checkMemory = require('./memory-checker');
 const createRpcClient = require('./create-rpc-client');
+const createHttpPatch = require('./create-http-patch');
 
 // Sometimes tests want to pass in an app object defined directly in the test,
 // so allow for that.
@@ -25,6 +26,11 @@ const loadApp = (appRawOrPath) => {
 const createLambdaHandler = (appRawOrPath) => {
 
   const handler = (event, context, callback) => {
+    // Adds logging for _all_ kinds of http(s) requests, no matter the library
+    const httpPatch = createHttpPatch(event);
+    httpPatch(require('http'));
+    // httpPatch(require('https')); // NOTE: This was double-logging
+
     // Wait for all async events to complete before callback returns.
     // This is not strictly necessary since this is the default now when
     // using the callback; just putting it here to be explicit.

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -28,8 +28,7 @@ const createLambdaHandler = (appRawOrPath) => {
   const handler = (event, context, callback) => {
     // Adds logging for _all_ kinds of http(s) requests, no matter the library
     const httpPatch = createHttpPatch(event);
-    httpPatch(require('http'));
-    // httpPatch(require('https')); // NOTE: This was double-logging
+    httpPatch(require('http'));// 'https' uses 'http' under the hood
 
     // Wait for all async events to complete before callback returns.
     // This is not strictly necessary since this is the default now when

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -7,9 +7,7 @@ const cleaner = require('./cleaner');
 const dataTools = require('./data');
 const hashing = require('./hashing');
 const ZapierPromise = require('./promise');
-
-const DEFAULT_LOGGING_HTTP_ENDPOINT = 'https://httplogger.zapier.com/input';
-const DEFAULT_LOGGING_HTTP_API_KEY = 'R24hzu86v3jntwtX2DtYECeWAB';
+const constants = require('../constants');
 
 const truncate = (str) => _.truncate(str, {length: 3500, omission: ' [...]'});
 
@@ -115,11 +113,12 @@ const sendLog = (options, event, message, data) => {
   }
 
   if (options.token) {
-    return request(httpOptions).catch(err => {
-      // Swallow logging errors.
-      // This will show up in AWS logs at least:
-      console.error('Error making log request:', err, 'http options:', httpOptions);
-    });
+    return request(httpOptions)
+      .catch(err => {
+        // Swallow logging errors.
+        // This will show up in AWS logs at least:
+        console.error('Error making log request:', err, 'http options:', httpOptions);
+      });
   } else {
     return ZapierPromise.resolve();
   }
@@ -134,10 +133,9 @@ const createLogger = (event, options) => {
   event = event || {};
 
   options = _.defaults(options, {
-    endpoint: process.env.LOGGING_ENDPOINT || DEFAULT_LOGGING_HTTP_ENDPOINT,
-    // TODO: can drop apiKey after https://github.com/zapier/http-to-gelf/pull/1 ships
-    apiKey: process.env.LOGGING_API_KEY || DEFAULT_LOGGING_HTTP_API_KEY,
-    token: event.token
+    endpoint: process.env.LOGGING_ENDPOINT || constants.DEFAULT_LOGGING_HTTP_ENDPOINT,
+    apiKey: process.env.LOGGING_API_KEY || constants.DEFAULT_LOGGING_HTTP_API_KEY,
+    token: process.env.LOGGING_TOKEN || event.token,
   });
 
   return sendLog.bind(undefined, options, event);

--- a/src/tools/request-merge.js
+++ b/src/tools/request-merge.js
@@ -51,8 +51,8 @@ const requestMerge = (requestOne, requestTwo) => {
     method: 'GET',
     params: {},
     headers: {
-      'user-agent': 'Zapier'
-    }
+      'user-agent': 'Zapier',
+    },
   };
 
   const request = caseInsensitiveMerge(baseRequest, requestOne, requestTwo);

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -12,6 +12,22 @@ describe('request client', () => {
   const testLogger = () => Promise.resolve({});
   const input = createInput({}, {}, testLogger);
 
+  it('should include a user-agent header', (done) => {
+    const request = createAppRequestClient(input);
+    request({url: 'http://zapier-httpbin.herokuapp.com/get'})
+      .then(responseBefore => {
+        const response = JSON.parse(JSON.stringify(responseBefore));
+
+        response.request.headers['user-agent'].should.eql('Zapier');
+        response.status.should.eql(200);
+
+        const body = JSON.parse(response.content);
+        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        done();
+      })
+      .catch(done);
+  });
+
   it('should have json serializable response', (done) => {
     const request = createAppRequestClient(input);
     request({url: 'http://zapier-httpbin.herokuapp.com/get'})

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -28,6 +28,30 @@ describe('request client', () => {
       .catch(done);
   });
 
+  it('should allow overriding the user-agent header', (done) => {
+    const request = createAppRequestClient(input);
+    request({
+      url: 'http://zapier-httpbin.herokuapp.com/get',
+      headers: {
+        'User-Agent': 'Zapier!',
+      },
+    })
+      .then(responseBefore => {
+        const response = JSON.parse(JSON.stringify(responseBefore));
+
+        console.log(response.request.headers);
+
+        should(response.request.headers['user-agent']).eql(undefined);
+        response.request.headers['User-Agent'].should.eql('Zapier!');
+        response.status.should.eql(200);
+
+        const body = JSON.parse(response.content);
+        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        done();
+      })
+      .catch(done);
+  });
+
   it('should have json serializable response', (done) => {
     const request = createAppRequestClient(input);
     request({url: 'http://zapier-httpbin.herokuapp.com/get'})


### PR DESCRIPTION
This provides more logging even if `z.request` isn't used (like when SDKs are used), by patching the `http` library in node.

This was tested with Dropbox and the interpreter "full test" app (with different non-client http/request libraries).

[Relevant Trello Card](https://trello.com/c/uUo9ZCoU/193-cli-track-all-outgoing-requests-whatever-library-is-used).

### What this changes

- [x] Logs requests (safely) for any http(s) request happening, outside of `z.request`.
- [x] Uses the `user-agent: Zapier` http header to differentiate from client requests and non-client ones.
- [x] Adds the ability to test logging locally in other apps, via `process.env.LOGGING_TOKEN`.
- [x] Adds a `request_via_client: Boolean` data property for GL, to differentiate from the different logs.
- [x] Doesn't log the requests that are made to GL
- [x] Adds a couple of tests test for the `user-agent` header

### Log

---

**Log http(s) requests for non-client library** (f9111da)

Fixes https://trello.com/c/uUo9ZCoU/193-cli-track-all-outgoing-requests-whatever-library-is-used

This also adds a "user-agent: Zapier" header, which is used to differentiate from client requests and non-client ones.

It also adds the ability to test logging locally in other apps, via the `process.env.LOGGING_TOKEN`

---

**Removing memory leak and adding more tests** (c84f6d9)

---

**Don't set encoding.** (f846d6e)