### PR TITLE
Encode form requests with + instead of %20 by default

### DIFF
--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -39,8 +39,7 @@ const coerceBody = (req) => {
 
   // auto coerce form if header says so
   if (contentType === FORM_TYPE && req.body && !_.isString(req.body)) {
-    // TODO: use const FormData = require('form-data'); instead?
-    req.body = querystring.stringify(req.body);
+    req.body = querystring.stringify(req.body).replace(/%20/g, '+');
   }
 
   if (isStream(req.body)) {


### PR DESCRIPTION
Most apps and the specs (read https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent on application/x-www-form-urlencoded) expect a plus sign instead of %20 in this situation.

Tests were also added. This will probably require a breaking release.

Fixes https://github.com/zapier/zapier-platform-cli/issues/161

Thoughts @bcooksey ?