### PR TITLE
Replace _.truncate, save memory.

### DIFF
--- a/src/checks/create-is-single.js
+++ b/src/checks/create-is-single.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { simpleTruncate } = require('../tools/data');
 
 const isCreate = require('./is-create');
 
@@ -12,7 +13,7 @@ const createIsSingle = {
   shouldRun: isCreate,
   run: (method, results) => {
     if (_.isArray(results)) {
-      const repr = _.truncate(JSON.stringify(results), 50);
+      const repr = simpleTruncate(JSON.stringify(results), 50);
       return [
         `Got a result with multiple return values, expecting a single object from create (${repr})`
       ];

--- a/src/checks/search-is-array.js
+++ b/src/checks/search-is-array.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { simpleTruncate } = require('../tools/data');
 
 const isSearch = require('./is-search');
 
@@ -12,7 +13,7 @@ const searchIsArray = {
   shouldRun: isSearch,
   run: (method, results) => {
     if (!_.isArray(results)) {
-      const repr = _.truncate(JSON.stringify(results), 50);
+      const repr = simpleTruncate(JSON.stringify(results), 50);
       return [
         `Results must be an array, got: ${typeof results}, (${repr})`
       ];

--- a/src/checks/trigger-has-id.js
+++ b/src/checks/trigger-has-id.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { simpleTruncate } = require('../tools/data');
 
 const isTrigger = require('./is-trigger');
 
@@ -19,7 +20,7 @@ const triggerHasId = {
     });
 
     if (missingIdResult) {
-      const repr = _.truncate(JSON.stringify(missingIdResult), 250);
+      const repr = simpleTruncate(JSON.stringify(missingIdResult), 250);
       return [
         `Got a result missing the "id" property (${repr})`
       ];

--- a/src/checks/trigger-has-unique-ids.js
+++ b/src/checks/trigger-has-unique-ids.js
@@ -23,7 +23,6 @@ const triggerHasUniqueIds = {
     });
 
     if (doubleId !== undefined) {
-      //const repr = _.truncate(JSON.stringify(missingIdResult), 50);
       return [
         `Got a two or more results with the id of ${doubleId}`
       ];

--- a/src/checks/trigger-is-array.js
+++ b/src/checks/trigger-is-array.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { simpleTruncate } = require('../tools/data');
 
 const isTrigger = require('./is-trigger');
 
@@ -12,7 +13,7 @@ const triggerIsArray = {
   shouldRun: isTrigger,
   run: (method, results) => {
     if (!_.isArray(results)) {
-      const repr = _.truncate(JSON.stringify(results), 50);
+      const repr = simpleTruncate(JSON.stringify(results), 50);
       return [
         `Results must be an array, got: ${typeof results}, (${repr})`
       ];

--- a/src/checks/trigger-is-object.js
+++ b/src/checks/trigger-is-object.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { simpleTruncate } = require('../tools/data');
 
 const isTrigger = require('./is-trigger');
 
@@ -20,7 +21,7 @@ const triggerIsObject = {
     });
 
     if (nonObjectResult !== undefined) {
-      const repr = _.truncate(JSON.stringify(nonObjectResult), 50);
+      const repr = simpleTruncate(JSON.stringify(nonObjectResult), 50);
       return [
         `Got a result missing that was not an object (${repr})`
       ];

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -9,7 +9,7 @@ const hashing = require('./hashing');
 const ZapierPromise = require('./promise');
 const constants = require('../constants');
 
-const truncate = (str) => _.truncate(str, {length: 3500, omission: ' [...]'});
+const truncate = (str) => dataTools.simpleTruncate(str, 3500, ' [...]');
 
 // format HTTP request details into string suitable for printing to stdout
 const httpDetailsLogMessage = (data) => {

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -128,6 +128,20 @@ const flattenPaths = (data, sep) => {
   return out;
 };
 
+// A simpler, and memory-friendlier version of _.truncate()
+const simpleTruncate = (string, length, suffix) => {
+  if (!string || !string.toString || string.toString().length === 0) {
+    return '';
+  }
+
+  if (string.toString().length > length) {
+    const cutoff = (suffix ? length - suffix.length : length);
+    return string.toString().substr(0, cutoff) + (suffix ? suffix : '');
+  }
+
+  return string;
+};
+
 module.exports = {
   isPlainObj,
   findMapDeep,
@@ -136,5 +150,6 @@ module.exports = {
   jsonCopy,
   deepFreeze,
   recurseReplace,
-  flattenPaths
+  flattenPaths,
+  simpleTruncate,
 };

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -130,13 +130,17 @@ const flattenPaths = (data, sep) => {
 
 // A simpler, and memory-friendlier version of _.truncate()
 const simpleTruncate = (string, length, suffix) => {
-  if (!string || !string.toString || string.toString().length === 0) {
+  if (!string || !string.toString) {
     return '';
   }
 
-  if (string.toString().length > length) {
+  const finalString = string.toString();
+
+  if (finalString.length === 0) {
+    return '';
+  } else if (finalString.length > length) {
     const cutoff = (suffix ? length - suffix.length : length);
-    return string.toString().substr(0, cutoff) + (suffix ? suffix : '');
+    return finalString.substr(0, cutoff) + (suffix ? suffix : '');
   }
 
   return string;

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -55,6 +55,30 @@ describe('Tools', () => {
     hashing.snipify('hello!').should.eql(':censored:6:f5dab4e158:');
   });
 
+  it('should truncate many things!', () => {
+    const tests = [
+      {value: null, length: 5, suffix: undefined, expected: ''},
+      {value: undefined, length: 5, suffix: '...', expected: ''},
+      {value: false, length: 5, suffix: '...', expected: ''},
+      {value: '', length: 5, suffix: undefined, expected: ''},
+      {value: [], length: 5, suffix: '...', expected: ''},
+      {value: {}, length: 5, suffix: '...', expected: '[o...'},
+      {value: () => {}, length: 5, suffix: '...', expected: '()...'},
+      {value: {yeah: true}, length: 8, suffix: '...', expected: '[obje...'},
+      {value: 'Something', length: 5, suffix: undefined, expected: 'Somet'},
+      {value: 'Something', length: 5, suffix: '...', expected: 'So...'},
+      {value: new Buffer('Something'), length: 7, suffix: ' [...]', expected: 'S [...]'},
+      {value: 'Something', length: 0, suffix: '...', expected: '...'},
+      {value: 'Something', length: 8, suffix: '...', expected: 'Somet...'},
+      {value: 'Something', length: 9, suffix: '...', expected: 'Something'},
+      {value: 'Something', length: 15, suffix: '...', expected: 'Something'},
+    ];
+
+    tests.forEach((test) => {
+      dataTools.simpleTruncate(test.value, test.length, test.suffix).should.eql(test.expected);
+    });
+  });
+
   // it('should prepareRequestLog', () => {
   //   const request = {
   //     url: 'http://www.google.com',

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -72,6 +72,8 @@ describe('Tools', () => {
       {value: 'Something', length: 8, suffix: '...', expected: 'Somet...'},
       {value: 'Something', length: 9, suffix: '...', expected: 'Something'},
       {value: 'Something', length: 15, suffix: '...', expected: 'Something'},
+      {value: 'Somèt°˜ı¡•ﬁ⁄', length: 9, suffix: '...', expected: 'Somèt°...'},
+      {value: 'Somèt°˜ı¡•ﬁ⁄', length: 12, suffix: '...', expected: 'Somèt°˜ı¡•ﬁ⁄'},
     ];
 
     tests.forEach((test) => {


### PR DESCRIPTION
Fixes #53

Memory usage for truncating a 25MB file went from a 900-1000MB spike to a **130-160MB** spike! I also confirmed the output matched in both situations (`_.truncate()` actually just "appended" the `omission`, while now we make sure the string doesn't go over the defined length _including_ the `suffix`, but I think it like it better this way).

Also, plenty of tests were added for it, and a few other places that were using `_.truncate()` were updated too.