### PR TITLE
Ignore 'tags' when building

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -29,4 +29,5 @@ find . -print | \
     grep -v "\.md" | \
     grep -v "\.sh" | \
     grep -v "\.zip" | \
+    grep -v "^./tags$" | \
     zip $1 -@

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -29,5 +29,5 @@ find . -print | \
     grep -v "\.md" | \
     grep -v "\.sh" | \
     grep -v "\.zip" | \
-    grep -v "^./tags$" | \
+    grep -v "^\./tags$" | \
     zip $1 -@


### PR DESCRIPTION
'tags' file is generated by ctags and used to help navigating code to ease development. It was accidentally packed into 4.1.0 package by a person (me) who uses ctags. It should be removed from the package.

Related: zapier/zapier-platform-cli#165

P.S. For the longer term, I think it's best to use Travis CI to help us release production builds to avoid this kind of problem.