### PR TITLE
Fix TypeError on requestUrl.indexOf

### DIFF
--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -18,10 +18,20 @@ const createHttpPatch = event => {
 
     // Proxy the request method
     object.request = (options, callback) => {
-      const requestUrl =
-        options.url ||
-        options.href ||
-        `${options.protocol || 'https://'}${options.host}${options.path}`;
+      // `options` can be an object or a string. If options is a string, it is
+      // automatically parsed with url.parse().
+      // See https://nodejs.org/docs/latest-v6.x/api/http.html#http_http_request_options_callback
+      let requestUrl;
+      if (typeof options === 'string') {
+        requestUrl = options;
+      } else {
+        requestUrl =
+          options.href ||
+          `${(options.protocol || 'https:') + '//'}${options.host}${
+            options.path
+          }`;
+      }
+
       const logger_url =
         process.env.LOGGING_ENDPOINT || constants.DEFAULT_LOGGING_HTTP_ENDPOINT;
 

--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -27,9 +27,7 @@ const createHttpPatch = event => {
       } else {
         requestUrl =
           options.href ||
-          `${(options.protocol || 'https:') + '//'}${options.host}${
-            options.path
-          }`;
+          `${options.protocol || 'https:'}//${options.host}${options.path}`;
       }
 
       const logger_url =


### PR DESCRIPTION
Encountered the following error when I was working on zapier/zapier-platform-cli#208. 

```
  1) Searches - Full Search
       should get an object:
     TypeError: requestUrl.indexOf is not a function
      at Object.object.request (node_modules/zapier-platform-core/src/tools/create-http-patch.js:25:22)
      at Request.start (node_modules/request/request.js:748:32)
      at Request.end (node_modules/request/request.js:1512:10)
      at end (node_modules/request/request.js:561:14)
      at Immediate.<anonymous> (node_modules/request/request.js:575:7)
      at Function.module.exports.loopWhile (node_modules/deasync/index.js:72:22)
      at node_modules/deasync/index.js:44:19
      at Object.request (node_modules/zapier-platform-legacy-scripting-runner/z.js:97:22)
      at Object.full_search_search (scripting.js:97:26)
      at e (node_modules/zapier-platform-legacy-scripting-runner/index.js:108:33)
      at Object.runEvent (node_modules/zapier-platform-legacy-scripting-runner/index.js:32:35)
      at getList (searches/full_search.js:23:6)
      at execute (node_modules/zapier-platform-core/src/execute.js:68:12)
      at node_modules/zapier-platform-core/src/create-command-handler.js:26:12
      at Object.beforeMiddleware.then.newInput (node_modules/zapier-platform-core/src/middleware.js:91:24)
      at bound (domain.js:280:14)
      at Object.runBound (domain.js:293:12)
```

Turned out that `options.url` is an object as opposed to a string in this failed test case. According to [http.request's doc](https://nodejs.org/docs/latest-v6.x/api/http.html#http_http_request_options_callback), `options` is either a string (URL) or an object (request options). It doesn't say anything about `options.url`. I'm not sure why the previous implementation did `options.url || options.href`, but here we go.