### PR TITLE
don't use buffer constructor

### DIFF
--- a/integration-test/integration-test.js
+++ b/integration-test/integration-test.js
@@ -24,7 +24,7 @@ const runLambda = event => {
         return reject(err);
       }
 
-      const logs = new Buffer(data.LogResult, 'base64').toString();
+      const logs = new Buffer.from(data.LogResult, 'base64').toString();
       console.log('\n=== LOGS ===\n', logs, '\n===\n');
 
       const response = data.Payload ? JSON.parse(data.Payload) : data;

--- a/integration-test/integration-test.js
+++ b/integration-test/integration-test.js
@@ -24,7 +24,7 @@ const runLambda = event => {
         return reject(err);
       }
 
-      const logs = new Buffer.from(data.LogResult, 'base64').toString();
+      const logs = Buffer.from(data.LogResult, 'base64').toString();
       console.log('\n=== LOGS ===\n', logs, '\n===\n');
 
       const response = data.Payload ? JSON.parse(data.Payload) : data;

--- a/src/http-middlewares/before/add-basic-auth-header.js
+++ b/src/http-middlewares/before/add-basic-auth-header.js
@@ -3,7 +3,7 @@
 // Computes the basic auth header for the request
 const addBasicAuthHeader = (req, z, bundle) => {
   if (bundle.authData && bundle.authData.username && bundle.authData.password) {
-    const buff = new Buffer(
+    const buff = Buffer.from(
       `${bundle.authData.username}:${bundle.authData.password}`,
       'utf8'
     );

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -67,7 +67,7 @@ const coerceBody = req => {
     // leave a stream/pipe alone!
   } else if (isPromise(req.body)) {
     // leave a promise alone!
-  } else if (_.isBuffer(req.body)) {
+  } else if (Buffer.isBuffer(req.body)) {
     // leave a buffer alone!
   } else if (req.body && !_.isString(req.body)) {
     // this is a general - popular fallback

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -121,7 +121,7 @@ describe('request client', () => {
     request({
       method: 'POST',
       url: 'http://zapier-mockbin.herokuapp.com/request', // httpbin doesn't handle chunked anything :-(
-      body: new Buffer.from('hello world this is a cat (=^..^=)')
+      body: Buffer.from('hello world this is a cat (=^..^=)')
     })
       .then(response => {
         response.status.should.eql(200);

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -121,7 +121,7 @@ describe('request client', () => {
     request({
       method: 'POST',
       url: 'http://zapier-mockbin.herokuapp.com/request', // httpbin doesn't handle chunked anything :-(
-      body: new Buffer('hello world this is a cat (=^..^=)')
+      body: new Buffer.from('hello world this is a cat (=^..^=)')
     })
       .then(response => {
         response.status.should.eql(200);

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -68,7 +68,7 @@ describe('Tools', () => {
       { value: 'Something', length: 5, suffix: undefined, expected: 'Somet' },
       { value: 'Something', length: 5, suffix: '...', expected: 'So...' },
       {
-        value: new Buffer.from('Something'),
+        value: Buffer.from('Something'),
         length: 7,
         suffix: ' [...]',
         expected: 'S [...]'

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -68,7 +68,7 @@ describe('Tools', () => {
       { value: 'Something', length: 5, suffix: undefined, expected: 'Somet' },
       { value: 'Something', length: 5, suffix: '...', expected: 'So...' },
       {
-        value: new Buffer('Something'),
+        value: new Buffer.from('Something'),
         length: 7,
         suffix: ' [...]',
         expected: 'S [...]'

--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -46,7 +46,7 @@ describe('file upload', () => {
     mocky.mockRpcCall(mocky.fakeSignedPostData);
     mocky.mockUpload();
 
-    const file = new Buffer.from('hello world this is a buffer of text');
+    const file = Buffer.from('hello world this is a buffer of text');
     stashFile(file)
       .then(url => {
         should(url).eql(
@@ -119,8 +119,8 @@ describe('file upload', () => {
     mocky.mockRpcCall(mocky.fakeSignedPostData);
     mocky.mockUpload();
 
-    const file = Promise.resolve().then(
-      () => new Buffer.from('7468697320697320612074c3a97374', 'hex')
+    const file = Promise.resolve().then(() =>
+      Buffer.from('7468697320697320612074c3a97374', 'hex')
     );
 
     stashFile(file)

--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -46,7 +46,7 @@ describe('file upload', () => {
     mocky.mockRpcCall(mocky.fakeSignedPostData);
     mocky.mockUpload();
 
-    const file = new Buffer('hello world this is a buffer of text');
+    const file = new Buffer.from('hello world this is a buffer of text');
     stashFile(file)
       .then(url => {
         should(url).eql(
@@ -120,7 +120,7 @@ describe('file upload', () => {
     mocky.mockUpload();
 
     const file = Promise.resolve().then(
-      () => new Buffer('7468697320697320612074c3a97374', 'hex')
+      () => new Buffer.from('7468697320697320612074c3a97374', 'hex')
     );
 
     stashFile(file)


### PR DESCRIPTION
Cousin PR of [this one](https://github.com/zapier/zapier-platform-cli/pull/213).

There's also a change to use `Buffer.isBuffer` instead of `_.isBuffer`, which uses the former under the hood. Consistency seems like a good thing. 