### PR TITLE
Fix http.request patch so it accepts options.url

### DIFF
--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -24,6 +24,10 @@ const createHttpPatch = event => {
       let requestUrl;
       if (typeof options === 'string') {
         requestUrl = options;
+      } else if (typeof options.url === 'string') {
+        // XXX: Somehow options.url is available for some requests although http.request doesn't really accept it.
+        // Without this else-if, many HTTP requests don't work. Should take a deeper look at this weirdness.
+        requestUrl = options.url;
       } else {
         requestUrl =
           options.href ||


### PR DESCRIPTION
#59 broke the existing code. Some HTTP requests don't work because of that. This PR fixes the problem by looking at `options.url` in `http.request`'s patch, bringing back the previous behavior.