### PR TITLE
For gzip encoded response, unzip before logging response.

### DIFF
--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -1,3 +1,4 @@
+const zlib = require('zlib');
 const _ = require('lodash');
 const constants = require('../constants');
 
@@ -57,9 +58,10 @@ const createHttpPatch = event => {
           Object.keys(response.headers || {}),
           header => `${header}: ${response.headers[header]}`
         );
-        const responseBody = [];
 
-        const logResponse = () => {
+        const chunks = [];
+
+        const sendToLogger = (responseBody) => {
           // Prepare data for GL
           const logData = {
             log_type: 'http',
@@ -71,7 +73,7 @@ const createHttpPatch = event => {
             request_via_client: false,
             response_status_code: response.statusCode,
             response_headers: responseHeaders.join('\n'),
-            response_content: responseBody.join('')
+            response_content: responseBody
           };
 
           logger(
@@ -82,7 +84,21 @@ const createHttpPatch = event => {
           );
         };
 
-        response.on('data', chunk => responseBody.push(chunk.toString()));
+        const logResponse = () => {
+          // Decode gzip if needed
+          if(_.get(responseHeaders, 'content-encoding', '') === 'gzip') {
+            const buffer = Buffer.concat(chunks);
+            zlib.gunzip(buffer, (err, decoded) => {
+              const responseBody = err ? 'Could not decode response body.' : decoded.toString();
+              sendToLogger(responseBody);
+            });
+          } else {
+            const responseBody = _.map(chunks, chunk => chunk.toString()).join('\n');
+            sendToLogger(responseBody);
+          }
+        };
+
+        response.on('data', chunk => chunks.push(chunk));
         response.on('end', logResponse);
         response.on('error', logResponse);
 

--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -61,7 +61,7 @@ const createHttpPatch = event => {
 
         const chunks = [];
 
-        const sendToLogger = (responseBody) => {
+        const sendToLogger = responseBody => {
           // Prepare data for GL
           const logData = {
             log_type: 'http',
@@ -86,14 +86,19 @@ const createHttpPatch = event => {
 
         const logResponse = () => {
           // Decode gzip if needed
-          if(_.get(responseHeaders, 'content-encoding', '') === 'gzip') {
+          if (response.headers['content-encoding'] === 'gzip') {
             const buffer = Buffer.concat(chunks);
             zlib.gunzip(buffer, (err, decoded) => {
-              const responseBody = err ? 'Could not decode response body.' : decoded.toString();
+              const responseBody = err
+                ? 'Could not decode response body.'
+                : decoded.toString();
+
               sendToLogger(responseBody);
             });
           } else {
-            const responseBody = _.map(chunks, chunk => chunk.toString()).join('\n');
+            const responseBody = _.map(chunks, chunk => chunk.toString()).join(
+              '\n'
+            );
             sendToLogger(responseBody);
           }
         };


### PR DESCRIPTION
This fixes https://github.com/zapier/zapier/issues/14888

The issue is on all gzip encoded responses. Here's a recent Graylog entry with bad response content: https://logs.internal.zapier.com/messages/graylog_1833/c0394913-faaf-11e7-be8a-0e0ca1cbbd4e

I would like some help in testing this locally with an actual CLI app to verify the fix on Graylog (probably on staging).