### PR TITLE
log when there's a key collision

### DIFF
--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -115,6 +115,7 @@ const compileApp = appRaw => {
   });
 
   if (problemKeys.length) {
+    // TODO - DB: throw an error instead of logging
     console.log(
       '\nWARNING! The following key(s) conflict with those created by a resource:\n'
     );
@@ -122,7 +123,8 @@ const compileApp = appRaw => {
       problemKeys.map(k => `* ${k}`).join('\n'),
       `\n\nEdit the standalone object${
         problemKeys.length > 1 ? 's' : ''
-      } to resolve\n`
+      } to resolve`,
+      '!! In the next major version, this will throw an error\n'
     );
   }
 

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -101,6 +101,31 @@ const compileApp = appRaw => {
   appRaw = dataTools.deepCopy(appRaw);
   const extras = convertResourceDos(appRaw);
 
+  const actions = ['triggers', 'searches', 'creates', 'searchOrCreates'];
+  let problemKeys = [];
+
+  actions.forEach(a => {
+    const collisions = _.intersection(
+      Object.keys(extras[a] || {}),
+      Object.keys(appRaw[a] || {})
+    );
+    if (collisions.length) {
+      problemKeys = problemKeys.concat(collisions.map(k => `${a}.${k}`));
+    }
+  });
+
+  if (problemKeys.length) {
+    console.log(
+      '\nWARNING! The following key(s) conflict with those created by a resource:\n'
+    );
+    console.log(
+      problemKeys.map(k => `* ${k}`).join('\n'),
+      `\n\nEdit the standalone object${
+        problemKeys.length > 1 ? 's' : ''
+      } to resolve\n`
+    );
+  }
+
   appRaw.triggers = _.extend({}, extras.triggers, appRaw.triggers || {});
   appRaw.searches = _.extend({}, extras.searches, appRaw.searches || {});
   appRaw.creates = _.extend({}, extras.creates, appRaw.creates || {});


### PR DESCRIPTION
mirrors to [PDE-35](https://zapierorg.atlassian.net/browse/PDE-35) and fixes https://github.com/zapier/zapier-platform-cli/issues/41

Since resources auto-generate keys for their new triggers/etc, we should flag if there's a collision (which will cause confusing behavior).

Notes: 

* Currently it just logs, doesn't throw an error (that would be a SEMVER-MAJOR, which we could do if we want (which I would 👍, there's not much to be gained by allowing key collisions)
* Logs very loudly since we check collisions during app compilation, which we do every time we call `createAppTester`. We could potentially fix this by letting `createLambdaHandler` know whether or not it's being used for a test or something else, but I think the louder the error is, the better. 
* Isn't currently tested (since the only side effect is writing to stdout), but is written in such a way that if we wanted to break it out, it's easy to test