### PR TITLE
Support test frameworks other than mocha

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const _process_args = process.argv.join(' ');
-const IS_TESTING = _process_args.indexOf('mocha') > 0;
+const IS_TESTING =
+  _process_args.indexOf('mocha') > 0 ||
+  _process_args.indexOf('jest') > 0 ||
+  (process.env.NODE_ENV || '').startsWith('test');
 
 const KILL_MIN_LIMIT = 250;
 const KILL_MAX_LIMIT = 450 * 1000 * 1000;


### PR DESCRIPTION
Mocha is _fine_, but there's a lot of other ways to test. I added another common one, plus checking for an env variable. 

Any test framework can be used by prepending the variable to the command in `package.json`:

```
"test": "NODE_ENV=testing my_test_framework"
```