### PR TITLE
[MAJOR] Remove bundle.environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,11 @@
     "preversion": "git pull && npm test",
     "version": "node bin/bump-dependencies.js && git add package.json",
     "postversion": "git push && git push --tags",
-    "test":
-      "node_modules/.bin/eslint src test && node_modules/.bin/mocha -t 5000 --recursive test",
-    "plain-test": "node_modules/.bin/mocha -t 3000 --recursive test",
-    "integration-test":
-      "node_modules/mocha/bin/mocha -t 10000 integration-test",
-    "lint": "node_modules/.bin/eslint src test",
+    "test": "mocha -t 5000 --recursive test",
+    "posttest": "npm run lint",
+    "plain-test": "mocha -t 3000 --recursive test",
+    "integration-test": "mocha -t 10000 integration-test",
+    "lint": "eslint src test",
     "build": "bin/build.sh local.bundle.zip",
     "upload": "bin/upload-lambda.js local.bundle.zip",
     "deploy":

--- a/src/tools/environment.js
+++ b/src/tools/environment.js
@@ -11,12 +11,8 @@ const { IS_TESTING } = require('../constants');
 // Copy bundle environment into process.env, and vice versa,
 // for convenience and compatibility with native environment vars.
 const applyEnvironment = event => {
-  event = ensurePath(event, 'bundle.environment'); // deprecated
-  _.extend(
-    process.env,
-    event.bundle.environment || {}, // deprecated
-    event.environment || {}
-  );
+  event = ensurePath(event, 'bundle');
+  _.extend(process.env, event.environment || {});
 };
 
 // Remove junk from process.env.


### PR DESCRIPTION
It's been deprecated since the first release, so it's a good a time as any to clean it out and make everything a little more consistent. 

**It should be noted** that I haven't been able to test this directly. It turns out it's a bear to build a zip with a different version of `core` in it (probably a good thing).

Anyway, the reason I think this is fine is because I've got an app that's been running an app in production that uses an environment variable but that value isn't present in the bundle:

```
% zapier env 1.0.0
The env of your "Steam" listed below.

┌─────────┬───────────────┬──────────────────────────────────┐
│ Version │ Key           │ Value                            │
├─────────┼───────────────┼──────────────────────────────────┤
│ 1.0.0   │ STEAM_API_KEY │ 8D5A1E0...                       │
└─────────┴───────────────┴──────────────────────────────────┘
```

``` % zapier logs
│     Log       │ { inputDataRaw: {},                                  │
│               │   meta:                                              │
│               │    { frontend: false,                                │
│               │      standard_poll: true,                            │
│               │      prefill: false,                                 │
│               │      test_poll: false,                               │
│               │      limit: -1,                                      │
│               │      hydrate: true,                                  │
│               │      first_poll: false,                              │
│               │      page: 0 },                                      │
│               │   authData: { steamid: ':censored:15:d607b82756:' }, │
│               │   inputData: {},                                     │
│               │   environment: {} }
```

the http logs are free of errors, which would only be the case if the api key was correctly set in the environment. 