### PR TITLE
Raise Exception for Bad Requests When Stashing A File

### DIFF
--- a/src/tools/create-file-stasher.js
+++ b/src/tools/create-file-stasher.js
@@ -117,7 +117,6 @@ const createFileStasher = input => {
                 } else {
                   newBufferStringStream = response.content;
                 }
-
                 knownLength =
                   knownLength || response.getHeader('content-length');
                 const cd = response.getHeader('content-disposition');
@@ -141,8 +140,8 @@ const createFileStasher = input => {
                 fileContentType
               );
             };
-
             if (isStreamed) {
+              maybeResponse.throwForStatus();
               return maybeResponse.buffer().then(parseFinalResponse);
             } else {
               return parseFinalResponse(maybeResponse);

--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const should = require('should');
+const nock = require('nock');
 
 const mocky = require('./mocky');
 
@@ -110,6 +111,27 @@ describe('file upload', () => {
             mocky.fakeSignedPostData.fields.key
           }`
         );
+        done();
+      })
+      .catch(done);
+  });
+
+  it('should throwForStatus if bad status', done => {
+    mocky.mockRpcCall(mocky.fakeSignedPostData);
+    mocky.mockUpload();
+
+    nock('http://example.com')
+      .get('/stream-bytes')
+      .reply(401);
+
+    const request = createAppRequestClient(input);
+    const file = request({
+      url: 'http://example.com/stream-bytes',
+      raw: true
+    });
+    stashFile(file)
+      .catch(err => {
+        should(err.message).containEql('Received 401 code from');
         done();
       })
       .catch(done);


### PR DESCRIPTION
## Description
Checks the status of a request for a file when attempting to stash said file

## Type of Changes
<!--- Put an `✓` for the applicable box: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Fixes #74

## Before / Current Behavior
Currently no checks are made when buffering a response into the file stasher - leading to `response.content` being called on a buffer, which raises an exception

## After / New Behavior
Will throw an exception if a non 200 status is returned when attempting to retrieve a file 