### PR TITLE
Better log censoring

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,17 @@ const REQUEST_OBJECT_SHORTHAND_OPTIONS = { replace: true };
 const DEFAULT_LOGGING_HTTP_ENDPOINT = 'https://httplogger.zapier.com/input';
 const DEFAULT_LOGGING_HTTP_API_KEY = 'R24hzu86v3jntwtX2DtYECeWAB'; // It's ok, this isn't PROD
 
+const SENSITIVE_KEYS = [
+  'api_key',
+  'apikey',
+  'auth',
+  'passwd',
+  'password',
+  'secret',
+  'signature',
+  'token'
+];
+
 module.exports = {
   IS_TESTING,
   KILL_MIN_LIMIT,
@@ -29,5 +40,6 @@ module.exports = {
   RENDER_ONLY_METHODS,
   REQUEST_OBJECT_SHORTHAND_OPTIONS,
   DEFAULT_LOGGING_HTTP_ENDPOINT,
-  DEFAULT_LOGGING_HTTP_API_KEY
+  DEFAULT_LOGGING_HTTP_API_KEY,
+  SENSITIVE_KEYS
 };

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -108,6 +108,22 @@ const recurseReplace = (obj, replacer) => {
   return obj;
 };
 
+// Recursively extract values from a nested object based on the matcher function.
+const recurseExtract = (obj, matcher) => {
+  const values = [];
+  Object.keys(obj).map(key => {
+    const value = obj[key];
+    if (matcher(key, value)) {
+      values.push(value);
+    } else if (isPlainObj(value)) {
+      recurseExtract(value, matcher).map(v => {
+        values.push(v);
+      });
+    }
+  });
+  return values;
+};
+
 const _IGNORE = {};
 
 // Flatten a nested object.
@@ -160,6 +176,7 @@ module.exports = {
   jsonCopy,
   deepFreeze,
   recurseReplace,
+  recurseExtract,
   flattenPaths,
   simpleTruncate
 };

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -185,6 +185,30 @@ describe('Tools', () => {
     });
   });
 
+  describe('recurseExtract', () => {
+    it('should extract values that match', () => {
+      const obj = {
+        secret_key: '1234',
+        another: {
+          secret_key: '5678',
+          deep: {
+            secret: 'abcd'
+          }
+        },
+        name: 'dont_care',
+        id: 88
+      };
+      const matcher = (key, value) => {
+        if (typeof value === 'string') {
+          return key.indexOf('secret') >= 0;
+        }
+        return false;
+      };
+      const values = dataTools.recurseExtract(obj, matcher);
+      values.should.eql(['1234', '5678', 'abcd']);
+    });
+  });
+
   describe('recurseCleanFuncs', () => {
     it('should handle objects, arrays and function->str', () => {
       var output = cleaner.recurseCleanFuncs({


### PR DESCRIPTION
Addresses #4 and zapier/zapier#16839.

So besides the original censoring on `authData`, this PR adds another step censoring based on the ad-hoc field names, similar to how [Sentry](https://github.com/getsentry/sentry/blob/8.10.0/src/sentry/constants.py#L166-L175) and [Django](https://docs.djangoproject.com/en/2.0/ref/settings/#debug) do it.