### PR TITLE
PoC: recurseCleanFuncs: option to preserve code

### DIFF
--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -6,23 +6,25 @@ const isPlainObj = require('./data').isPlainObj;
 const recurseReplace = require('./data').recurseReplace;
 const flattenPaths = require('./data').flattenPaths;
 
-const recurseCleanFuncs = (obj, path) => {
+const recurseCleanFuncs = (obj, toString = false) => {
   // mainly turn functions into $func${arity}${arguments}$
-  path = path || [];
   if (typeof obj == 'function') {
+    if (toString) {
+      return obj.toString();
+    }
     const usesArguments =
       obj.toString().indexOf('arguments') !== -1 ? 't' : 'f';
     // TODO: could optimize $func$0$f$ as "pure" and just render them
     return `$func$${obj.length}$${usesArguments}$`;
   } else if (Array.isArray(obj)) {
     return obj.map((value, i) => {
-      return recurseCleanFuncs(value, path.concat([i]));
+      return recurseCleanFuncs(value, withCode);
     });
   } else if (isPlainObj(obj)) {
     const newObj = {};
     Object.keys(obj).forEach(key => {
       const value = obj[key];
-      newObj[key] = recurseCleanFuncs(value, path.concat([key]));
+      newObj[key] = recurseCleanFuncs(value, withCode);
     });
     return newObj;
   }


### PR DESCRIPTION
Quick proof of concept that we could generate a `definition.json` which includes the actual function code. 

An example of the output for https://github.com/zapier/zapier-platform-example-app-onedrive:

https://gist.github.com/FokkeZB/c339a9cdc1220e260eca43148fbf0da9

Note: I replaced `path` since it didn't seem to be used anywhere?