### PR TITLE
Self enclosed dynamic schema.

### DIFF
--- a/integration-test/integration-test.js
+++ b/integration-test/integration-test.js
@@ -114,6 +114,33 @@ const doTest = runner => {
         .catch(done);
     });
 
+    it('should handle appRawOverride', done => {
+      const event = {
+        command: 'execute',
+        method: 'triggers.fooList.operation.perform',
+        appRawOverride: {
+          resources: {
+            foo: {
+              key: 'foo',
+              noun: 'Foo',
+              list: {
+                display: {},
+                operation: {
+                  perform: { source: 'return [{id: 45678}]' }
+                }
+              }
+            }
+          }
+        }
+      };
+      runner(event)
+        .then(response => {
+          response.results.should.deepEqual([{ id: 45678 }]);
+          done();
+        })
+        .catch(done);
+    });
+
     it('should log requests', done => {
       const event = {
         command: 'execute',

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -16,7 +16,10 @@ const createHttpPatch = require('./create-http-patch');
 
 // Sometimes tests want to pass in an app object defined directly in the test,
 // so allow for that.
-const loadApp = appRawOrPath => {
+const loadApp = (event, appRawOrPath) => {
+  if (event && event.appRawOverride) {
+    return event.appRawOverride;
+  }
   if (_.isString(appRawOrPath)) {
     return require(appRawOrPath);
   }
@@ -83,7 +86,7 @@ const createLambdaHandler = appRawOrPath => {
       // Copy bundle environment into process.env *before* loading app code,
       // so that top level app code can get bundle environment vars via process.env.
       environmentTools.applyEnvironment(event);
-      const appRaw = loadApp(appRawOrPath);
+      const appRaw = loadApp(event, appRawOrPath);
       const app = createApp(appRaw);
       const rpc = createRpcClient(event);
 

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -90,16 +90,19 @@ const deepFreeze = obj => {
 };
 
 // Recurse a nested object replace stuff according to the function.
-const recurseReplace = (obj, replacer) => {
+const recurseReplace = (obj, replacer, options = {}) => {
+  if (options.all) {
+    obj = replacer(obj);
+  }
   if (Array.isArray(obj)) {
     return obj.map(value => {
-      return recurseReplace(value, replacer);
+      return recurseReplace(value, replacer, options);
     });
   } else if (isPlainObj(obj)) {
     const newObj = {};
     Object.keys(obj).map(key => {
       const value = obj[key];
-      newObj[key] = recurseReplace(value, replacer);
+      newObj[key] = recurseReplace(value, replacer, options);
     });
     return newObj;
   } else {

--- a/src/tools/schema-tools.js
+++ b/src/tools/schema-tools.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const dataTools = require('./data');
+
+// TODO: bryanhelmig, could support callback third argument but not naively
+const makeFunction = source => {
+  try {
+    return Function('z', 'bundle', source); // eslint-disable-line no-new-func
+  } catch (err) {
+    return () => {
+      throw err;
+    };
+  }
+};
+
+const requireOrLazyError = path => {
+  try {
+    const func = require(path);
+    if (typeof func === 'function') {
+      return func;
+    }
+    throw new Error(`${path} does not export a function!`);
+  } catch (err) {
+    return () => {
+      throw err;
+    };
+  }
+};
+
+const findSourceRequireFunctions = appRaw => {
+  const replacer = obj => {
+    if (obj && typeof obj === 'object' && Object.keys(obj).length === 1) {
+      if (
+        typeof obj.source === 'string' &&
+        obj.source.indexOf('return') !== -1
+      ) {
+        obj = makeFunction(obj.source);
+      } else if (typeof obj.require === 'string' && obj.require) {
+        obj = requireOrLazyError(obj.require);
+      }
+    }
+    return obj;
+  };
+  appRaw = dataTools.recurseReplace(appRaw, replacer, { all: true });
+  return appRaw;
+};
+
+module.exports = {
+  makeFunction,
+  requireOrLazyError,
+  findSourceRequireFunctions
+};

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -3,22 +3,8 @@
 const _ = require('lodash');
 const cleaner = require('./cleaner');
 const dataTools = require('./data');
+const schemaTools = require('./schema-tools');
 const zapierSchema = require('zapier-platform-schema');
-
-const findSourceAndFunctionize = appRaw => {
-  const replacer = obj => {
-    if (
-      obj &&
-      typeof obj.source === 'string' &&
-      obj.source.indexOf('return') !== -1
-    ) {
-      obj = Function('z', 'bundle', 'callback', obj.source); // eslint-disable-line no-new-func
-    }
-    return obj;
-  };
-  appRaw = dataTools.recurseReplace(appRaw, replacer, { all: true });
-  return appRaw;
-};
 
 // Take a resource with methods like list/hook and turn it into triggers, etc.
 const convertResourceDos = appRaw => {
@@ -114,7 +100,7 @@ const copyPropertiesFromResource = (type, action, appRaw) => {
 
 const compileApp = appRaw => {
   appRaw = dataTools.deepCopy(appRaw);
-  appRaw = findSourceAndFunctionize(appRaw);
+  appRaw = schemaTools.findSourceRequireFunctions(appRaw);
   const extras = convertResourceDos(appRaw);
 
   const actions = ['triggers', 'searches', 'creates', 'searchOrCreates'];

--- a/test/moduleuserapp/export-func.js
+++ b/test/moduleuserapp/export-func.js
@@ -1,0 +1,3 @@
+module.exports = (z, bundle) => {
+  return [{ id: 1234 }] || bundle;
+};

--- a/test/tools/schema-tools.js
+++ b/test/tools/schema-tools.js
@@ -1,0 +1,33 @@
+'use strict';
+
+require('should');
+
+const path = require('path');
+const schemaTools = require('../../src/tools/schema-tools');
+
+describe('schema-tools', () => {
+  describe('makeFunction', () => {
+    it('should make a function', () => {
+      const func = schemaTools.makeFunction('return [{ id: 1234 }];');
+      func().should.deepEqual([{ id: 1234 }]);
+    });
+
+    it('should gracefully handle bad code', () => {
+      const func = schemaTools.makeFunction('return [{ id: 12');
+      func.should.throw(SyntaxError);
+    });
+  });
+
+  describe('requireOrLazyError', () => {
+    it('should require properly', () => {
+      const funcPath = path.resolve('test/moduleuserapp/export-func');
+      const func = schemaTools.requireOrLazyError(funcPath);
+      func().should.deepEqual([{ id: 1234 }]);
+    });
+
+    it('should wrap require fails', () => {
+      const func = schemaTools.requireOrLazyError('not/a/real/pathjs');
+      func.should.throw(/Cannot find module/);
+    });
+  });
+});

--- a/test/tools/schema-tools.js
+++ b/test/tools/schema-tools.js
@@ -25,6 +25,12 @@ describe('schema-tools', () => {
       func().should.deepEqual([{ id: 1234 }]);
     });
 
+    it('should wrap non-function fails', () => {
+      const funcPath = path.resolve('test/moduleuserapp/index');
+      const func = schemaTools.requireOrLazyError(funcPath);
+      func.should.throw(/does not export a function/);
+    });
+
     it('should wrap require fails', () => {
       const func = schemaTools.requireOrLazyError('not/a/real/pathjs');
       func.should.throw(/Cannot find module/);

--- a/test/tools/schema.js
+++ b/test/tools/schema.js
@@ -186,6 +186,27 @@ describe('schema', () => {
       });
     });
 
+    it('should turn {source: <code>} into Function', () => {
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            list: {
+              display: {},
+              operation: {
+                perform: { source: 'return [{id: 45678}]' }
+              }
+            }
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.triggers.fooList.operation
+        .perform()
+        .should.deepEqual([{ id: 45678 }]);
+    });
+
     it("should populate search's performGet from get method if available", () => {
       const appRaw = {
         resources: {

--- a/test/tools/schema.js
+++ b/test/tools/schema.js
@@ -186,27 +186,6 @@ describe('schema', () => {
       });
     });
 
-    it('should turn {source: <code>} into Function', () => {
-      const appRaw = {
-        resources: {
-          foo: {
-            key: 'foo',
-            noun: 'Foo',
-            list: {
-              display: {},
-              operation: {
-                perform: { source: 'return [{id: 45678}]' }
-              }
-            }
-          }
-        }
-      };
-      const compiledApp = schema.compileApp(appRaw);
-      compiledApp.triggers.fooList.operation
-        .perform()
-        .should.deepEqual([{ id: 45678 }]);
-    });
-
     it("should populate search's performGet from get method if available", () => {
       const appRaw = {
         resources: {

--- a/test/userapp/index.js
+++ b/test/userapp/index.js
@@ -78,6 +78,23 @@ const ContactError = {
   }
 };
 
+const ContactSource = {
+  key: 'contactsource',
+  noun: 'Contact Source',
+  list: {
+    display: {
+      label: 'New Contact With Source!',
+      description:
+        'Trigger on new contacts, but return a response via fake JS source.'
+    },
+    operation: {
+      perform: {
+        source: 'return [{ id: 1234 }];'
+      }
+    }
+  }
+};
+
 const LoggingFunc = {
   key: 'loggingfunc',
   noun: 'loggingfunc',
@@ -460,6 +477,7 @@ const App = {
     [List.key]: List,
     [Contact.key]: Contact,
     [ContactError.key]: ContactError,
+    [ContactSource.key]: ContactSource,
     [LoggingFunc.key]: LoggingFunc,
     [RequestFunc.key]: RequestFunc,
     [RequestSugar.key]: RequestSugar,


### PR DESCRIPTION
Handle a new case for `perform` functionality:

* _old_ `request` which is a hardcoded request object with embedded, lazy `{{}}` evaluation. EG: https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#requestschema
* _old_ `func` which is hardcoded functions from an on disk JS AST / zip. EG: https://github.com/zapier/zapier-platform-schema/blob/master/docs/build/schema.md#functionschema
* _new_ `source` which is `perform = {source: 'return [{id: 123}]'}` which we turn into `Function('z', 'bundle', perform.source)`. EG: https://github.com/zapier/zapier-platform-schema/pull/45 (an extension of above `func`).
* _new_ `require` which is `perform = {requuie: 'some/path/to/file.js'}` which we turn into `require(perform.require)`. EG: https://github.com/zapier/zapier-platform-schema/pull/45 (an extension of above `func`).

This is the first step in supporting CLI apps that could be "zipless" -- IE: just hand a generic core runner any self-enclosed schema and we can run it. This should be the first step on a path to no-build basic apps with JS support.

- [x] support `event.appRawOverride` in `loadApp(appRawOrPath)`.
- ~~[ ] explore the merging of app definitions (IE: `merge(appRaw, event.appRawOverride)`)~~  (maybe later)