### PR TITLE
Add typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,106 @@
+// Type definitions for zapier-platform-core
+// Project: Zapier's Platform Core
+// Definitions by: David Brownman <https://davidbrownman.com>
+
+/// <reference types="node" />
+
+import { Stream } from 'stream';
+import { Utf8AsciiLatin1Encoding, HexBase64Latin1Encoding } from 'crypto';
+import { Agent } from 'http';
+
+// The EXPORTED OBJECT
+export const version: string;
+export const tools: { env: { inject: (filename?: string) => void } };
+// export const createAppHandler: (appRaw: object) => any // internal
+export const createAppTester: (
+  appRaw: object
+) => (
+  func: (z: zObject, bundle: Bundle) => any,
+  bundle?: Bundle
+) => Promise<any>;
+// internal only
+// export const integrationTestHandler: () => void;
+
+interface Bundle {}
+
+declare class HaltedError extends Error {}
+declare class ExpiredAuthError extends Error {}
+declare class RefreshAuthError extends Error {}
+
+// copied http stuff from external typings
+export interface HttpRequestOptions {
+  url?: string;
+  method?: 'POST' | 'GET' | 'OPTIONS' | 'HEAD' | 'DELETE' | 'PATCH' | 'PUT';
+  body?: string | Buffer | NodeJS.ReadableStream | object;
+  headers?: { [name: string]: string };
+  json?: object | any[] | null;
+  params?: object;
+  form?: object;
+  raw?: boolean;
+  redirect?: 'manual' | 'error' | 'follow';
+  follow?: number;
+  compress?: boolean;
+  agent?: Agent;
+  timeout?: number;
+  size?: number;
+}
+
+export interface HttpResponse {
+  status: number;
+  content: string | Buffer;
+  json: object | undefined | Promise<object | undefined>;
+  body?: NodeJS.ReadableStream;
+  headers: { [key: string]: string };
+  getHeader(key: string): string | undefined;
+  throwForStatus(): void;
+  request: HttpRequestOptions;
+}
+
+export interface zObject {
+  request: {
+    (url: string, options?: HttpRequestOptions): Promise<HttpResponse>;
+    (options: HttpRequestOptions): Promise<HttpResponse>;
+  };
+
+  console: Console;
+
+  dehyrate: (func: (z: this, bundle: Bundle) => any, inputData: object) => void;
+
+  stashFile: {
+    (
+      input: string | Buffer | Stream,
+      knownLength?: number,
+      filename?: string,
+      contentType?: string
+    ): string;
+    (input: Promise<string>): string;
+  };
+
+  JSON: {
+    /**
+     * Acts a lot like regular `JSON.parse`, but throws a nice error for improper json input
+     */
+    parse: (text: string) => string;
+    stringify: typeof JSON.stringify;
+  };
+
+  /**
+   * Easily hash data using node's crypto package
+   * @param algorithm probably 'sha256', see [this](https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options) for more options
+   * @param data the data you want to hash
+   * @param encoding defaults to 'hex'
+   * @param input_encoding defaults to 'binary'
+   */
+  hash(
+    algorithm: string,
+    data: string,
+    encoding?: string,
+    input_encoding?: string
+  ): string;
+
+  errors: {
+    HaltedError: typeof HaltedError;
+    ExpiredAuthError: typeof ExpiredAuthError;
+    RefreshAuthError: typeof RefreshAuthError;
+  };
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Bryan Helmig <bryan@zapier.com>",
   "license": "UNLICENSED",
   "main": "index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "preversion": "git pull && npm test",
     "version": "node bin/bump-dependencies.js && git add package.json",


### PR DESCRIPTION
Mostly fixes https://github.com/zapier/zapier-platform-cli/issues/15. This adds a typing file to the root of the core repo. Going forward, we'll need to update the file whenever the API or options changes, but that should be pretty low key. The great news is that this doesn't get in the way of normal operations and even provides types to js users using VS Code (which picks these up for regular javascript).

This only covers the items and interfaces exported by core. Ideally we'll be able to turn the json schema into types at well, but there are some speedbumps there. Instead of holding back indefinitely, let's get these out and I can circle back for the rest at some point. 

To test, run the following commands: 

* `mkdir ts-test`
* `npm i typescript zapier-platform-core`
* `tsc --init`
* paste the below file into index.ts
* `tsc`
* should have no errors

The big thing is that the input and output types below match what's in the code. I went pretty carefully through the docs (and if they weren't clear, code), so it should all be there! I'm also using these for a ts zapier app (that'll be pushed soon), so know soon if there's anything I missed.

```ts
import { zObject, Bundle } from 'zapier-platform-core'

const getData = (z: zObject, bundle: Bundle) => {
  return 1
}

const perform = async (z: zObject, bundle: Bundle) => {
  // a request involving raw: true returns a different response object
  // should work if invoked with a url or with only an options object

  const rawUrlResponse = await z.request('asdf', { raw: true })
  console.log(rawUrlResponse.body) // .body only exists on the raw response

  const rawOptsResponse = await z.request({ raw: true, url: 'asdf' })
  console.log(rawOptsResponse.body)

  const urlResponse = await z.request('asdf', {
    headers: { a: '1' },
    method: 'GET'
  })
  console.log(urlResponse.content.fontsize(4)) // .fontsize assumes content is a string, which it should be

  const optsResponse = await z.request({ url: 'asdf' })
  console.log(optsResponse.content.fontsize(4))

  // fails if bundle.meta.frontend isn't a bool
  z.console.log(bundle.meta.frontend === false)
  z.console.error(bundle.meta.frontend)

  const dh = z.dehyrate(getData, { id: bundle.inputData.id })

  z.stashFile(new Buffer('asdf'))

  const obj = z.JSON.parse(optsResponse.content)
  const s = obj.id

  const hash = z.hash('sha256', 'my password')

  throw new z.errors.HaltedError('do better')
}
```