### PR TITLE
Support for big definition overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This is the code that powers our [Zapier Platform CLI](https://zapier.github.io/
 ## Development
 
 * `npm install` for getting started
-* `npm test` for running tests
+* `npm test` for running unit tests
+* `npm run local-integration-test` for running integration tests
 * `npm run build-boilerplate -- --debug` for building a `build-boilerplate/*.zip` (if you want to test buildless locally)
 
 ## Publishing (after merging)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the code that powers our [Zapier Platform CLI](https://zapier.github.io/
 
 * `npm install` for getting started
 * `npm test` for running tests
-* `npm run build-boilerplate` for building a `boilerplate.zip` (if you want to test buildless locally)
+* `npm run build-boilerplate -- --debug` for building a `build-boilerplate/*.zip` (if you want to test buildless locally)
 
 ## Publishing (after merging)
 

--- a/bin/build-boilerplate.sh
+++ b/bin/build-boilerplate.sh
@@ -2,6 +2,7 @@
 
 # Usage like so:
 # ./build-boilerplate.sh
+# ./build-boilerplate.sh --debug  # For pushing local changes into the zip file
 
 CONTENTS_DIR='boilerplate'
 BUILD_DIR='build-boilerplate'
@@ -9,8 +10,7 @@ BUILD_DIR='build-boilerplate'
 # This allows us to avoid duplicating files in git
 FILES_TO_COPY='zapierwrapper.js'
 
-if [ -d $BUILD_DIR ]
-then
+if [ -d $BUILD_DIR ]; then
    rm -fr $BUILD_DIR
 fi
 
@@ -35,6 +35,11 @@ sed -i '' -e "s/$FIND_DEF_STRING/$REPLACE_DEF_STRING/g" "$CONTENTS_DIR/definitio
 
 # Install dependencies
 cd $CONTENTS_DIR && npm install
+
+# Allow pushing "local changes" into the zip file
+if [ "$1" == "--debug" ]; then
+  cp -R ../src/* node_modules/zapier-platform-core/src/
+fi
 
 # Build the zip file!
 zip -R ../$FILE '*.js' '*.json'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "posttest": "npm run lint",
     "plain-test": "mocha -t 3000 --recursive test",
     "integration-test": "mocha -t 10000 integration-test",
+    "local-integration-test": "mocha -t 10000 integration-test --local",
+    "lambda-integration-test": "mocha -t 10000 integration-test --lambda",
     "lint": "eslint src test",
     "build": "bin/build.sh local.bundle.zip",
     "upload": "bin/upload-lambda.js local.bundle.zip",

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -22,7 +22,7 @@ const loadApp = (event, rpc, appRawOrPath) => {
       if (event.appRawOverride === true) {
         // appRawOverride is too big, so we fetch it via RPC
         return rpc('get_definition_override')
-          .then(appRawOverride => resolve(JSON.parse(appRawOverride)))
+          .then(appRawOverride => resolve(appRawOverride))
           .catch(err => reject(err));
       } else {
         return resolve(event.appRawOverride);

--- a/test/tools/rpc-client.js
+++ b/test/tools/rpc-client.js
@@ -1,32 +1,40 @@
 'use strict';
 
-const should = require('should');
-
 const mocky = require('./mocky');
 
 describe('rpc client', () => {
   const rpc = mocky.makeRpc();
 
-  it('should handle a ping', done => {
+  it('should handle a ping', () => {
     mocky.mockRpcCall('pong');
 
-    rpc('ping')
-      .then(result => {
-        should(result).eql('pong');
-      })
-      .then(() => done())
-      .catch(done);
+    return rpc('ping').then(result => {
+      result.should.eql('pong');
+    });
   });
 
-  it('should handle an explosion', done => {
+  it('should handle an explosion', () => {
     mocky.mockRpcFail('this is an expected explosion');
 
-    rpc('explode')
-      .then(() => done(new Error('this should have exploded')))
-      .catch(err => {
-        should(err.message).eql('this is an expected explosion');
-        done();
+    return rpc('explode')
+      .then(() => {
+        throw new Error('this should have exploded');
       })
-      .catch(done);
+      .catch(err => {
+        err.message.should.eql('this is an expected explosion');
+      });
+  });
+
+  it('should fetch a definition_override', () => {
+    const fakeDefinition = {
+      platformVersion: '1.0.0',
+      version: '1.0.0'
+    };
+
+    mocky.mockRpcCall(fakeDefinition);
+
+    return rpc('get_definition_override').then(result => {
+      result.should.eql(fakeDefinition);
+    });
   });
 });

--- a/test/userapp/index.js
+++ b/test/userapp/index.js
@@ -319,16 +319,12 @@ const DynamicAsyncInputFields = {
       description: 'input fields are a promise'
     },
     operation: {
-      inputFields: Promise.resolve([
-        { key: 'key 1' },
-        { key: 'key 2' },
-        { key: 'key 3' }
-      ]),
-      outputFields: Promise.resolve([
-        { key: 'key 1' },
-        { key: 'key 2' },
-        { key: 'key 3' }
-      ]),
+      inputFields: [
+        Promise.resolve([{ key: 'key 1' }, { key: 'key 2' }, { key: 'key 3' }])
+      ],
+      outputFields: [
+        Promise.resolve([{ key: 'key 1' }, { key: 'key 2' }, { key: 'key 3' }])
+      ],
       perform: () => {}
     }
   }


### PR DESCRIPTION
Using an RPC call to get those.

Also adds support for building a boilerplate zip with the current "local" changes, vs the latest npm package.

This needs https://github.com/zapier/zapier/pull/17392 to ship before merging this PR.

Related to [PDE-166](https://zapierorg.atlassian.net/browse/PDE-166).