### PR TITLE
Allow to functions accepting any args besides (z, bundle)

### DIFF
--- a/src/tools/schema-tools.js
+++ b/src/tools/schema-tools.js
@@ -2,10 +2,10 @@
 
 const dataTools = require('./data');
 
-// TODO: bryanhelmig, could support callback third argument but not naively
-const makeFunction = source => {
+const makeFunction = (source, args) => {
+  args = args || [];
   try {
-    return Function('z', 'bundle', source); // eslint-disable-line no-new-func
+    return Function.apply(null, args.concat([source]));
   } catch (err) {
     return () => {
       throw err;
@@ -29,14 +29,18 @@ const requireOrLazyError = path => {
 
 const findSourceRequireFunctions = appRaw => {
   const replacer = obj => {
-    if (obj && typeof obj === 'object' && Object.keys(obj).length === 1) {
-      if (
-        typeof obj.source === 'string' &&
-        obj.source.indexOf('return') !== -1
-      ) {
-        obj = makeFunction(obj.source);
-      } else if (typeof obj.require === 'string' && obj.require) {
-        obj = requireOrLazyError(obj.require);
+    if (obj && typeof obj === 'object') {
+      const numKeys = Object.keys(obj).length;
+      if (numKeys === 1 || numKeys === 2) {
+        if (
+          typeof obj.source === 'string' &&
+          obj.source.indexOf('return') !== -1
+        ) {
+          const args = obj.args || ['z', 'bundle'];
+          obj = makeFunction(obj.source, args);
+        } else if (typeof obj.require === 'string' && obj.require) {
+          obj = requireOrLazyError(obj.require);
+        }
       }
     }
     return obj;

--- a/test/tools/schema-tools.js
+++ b/test/tools/schema-tools.js
@@ -36,4 +36,14 @@ describe('schema-tools', () => {
       func.should.throw(/Cannot find module/);
     });
   });
+
+  describe('findSourceRequireFunctions', () => {
+    it('should replace beforeRequest source', () => {
+      const appRaw = {
+        beforeRequest: [{ source: 'return a - b;', args: ['a', 'b'] }]
+      };
+      const app = schemaTools.findSourceRequireFunctions(appRaw);
+      app.beforeRequest[0](123, 23).should.eql(100);
+    });
+  });
 });


### PR DESCRIPTION
Currently, the syntax of `{ source: 'return 123;' }` generates a function that accepts `(z, bundle)` as arguments. While this is mostly fine, not all functions in a CLI app take `(z, bundle)`. One example is the middleware functions in `beforeRequest` and `afterResponse`, which take `(request, z, bundle)` as arguments.

This PR fixes it by allowing the app definition to specify `args` as well. For example, `{ source: 'return a + b;', args: ['a', 'b'])`. If `args` isn't provided, we fall back to `(z, bundle)`.