### PR TITLE
Fix bug: Middleware isn't compiled

### DIFF
--- a/integration-test/integration-test.js
+++ b/integration-test/integration-test.js
@@ -165,6 +165,37 @@ const doTest = runner => {
         });
     });
 
+    it('should handle function source in beforeRequest', () => {
+      const definition = {
+        beforeRequest: [
+          {
+            source: "request.headers['X-Foo'] = 'it worked!'; return request",
+            args: ['request', 'z', 'bundle']
+          }
+        ],
+        creates: {
+          foo: {
+            operation: {
+              perform: {
+                method: 'POST',
+                url: 'https://zapier-httpbin.herokuapp.com/post'
+              }
+            }
+          }
+        }
+      };
+
+      const event = {
+        command: 'execute',
+        method: 'creates.foo.operation.perform',
+        appRawOverride: definition
+      };
+
+      return runner(event).then(response => {
+        response.results.headers['X-Foo'].should.eql('it worked!');
+      });
+    });
+
     it('should log requests', () => {
       const event = {
         command: 'execute',

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -15,6 +15,7 @@ const environmentTools = require('./environment');
 const checkMemory = require('./memory-checker');
 const createRpcClient = require('./create-rpc-client');
 const createHttpPatch = require('./create-http-patch');
+const schemaTools = require('./schema');
 
 const getAppRawOverride = (rpc, appRawOverride) => {
   return new ZapierPromise((resolve, reject) => {
@@ -135,7 +136,12 @@ const createLambdaHandler = appRawOrPath => {
       return loadApp(event, rpc, appRawOrPath)
         .then(appRaw => {
           const app = createApp(appRaw);
-          const input = createInput(appRaw, event, logger, logBuffer, rpc);
+
+          // TODO: Avoid repeated prepareApp(appRaw), createApp() already
+          // calls prepareApp() but doesn't return it.
+          const compiledApp = schemaTools.prepareApp(appRaw);
+
+          const input = createInput(compiledApp, event, logger, logBuffer, rpc);
           return app(input);
         })
         .then(output => {

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -137,8 +137,8 @@ const createLambdaHandler = appRawOrPath => {
         .then(appRaw => {
           const app = createApp(appRaw);
 
-          // TODO: Avoid repeated prepareApp(appRaw), createApp() already
-          // calls prepareApp() but doesn't return it.
+          // TODO: Avoid calling prepareApp(appRaw) repeatedly here as createApp()
+          // already calls prepareApp() but just doesn't return it.
           const compiledApp = schemaTools.prepareApp(appRaw);
 
           const input = createInput(compiledApp, event, logger, logBuffer, rpc);


### PR DESCRIPTION
Fixes the bug where `beforeRequest` and `afterResponse` middlewares don't get compiled from an embedded form like `{ source: 'return request;' }`.