### PR TITLE
Delegate legacy scripting source compilation to runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "files": [
-      "/include/",
-      "/index.d.ts",
-      "/index.js",
-      "/src/"
+    "/include/",
+    "/index.d.ts",
+    "/index.js",
+    "/src/"
   ],
   "scripts": {
     "preversion": "git pull && npm test",

--- a/src/tools/create-legacy-scripting-runner.js
+++ b/src/tools/create-legacy-scripting-runner.js
@@ -29,47 +29,7 @@ const createLegacyScriptingRunner = (z, app) => {
   if (!LegacyScriptingRunner) {
     return null;
   }
-
-  const scope = LegacyScriptingRunner.initScope();
-
-  const Zap = new Function( // eslint-disable-line no-new-func
-    '_',
-    'crypto',
-    'async',
-    'moment',
-    'DOMParser',
-    'XMLSerializer',
-    'atob',
-    'btoa',
-    'z',
-    '$',
-    'ErrorException',
-    'HaltedException',
-    'StopRequestException',
-    'ExpiredAuthException',
-    'RefreshTokenException',
-    'InvalidSessionException',
-    source + '\nreturn Zap;'
-  )(
-    scope._,
-    scope.crypto,
-    scope.async,
-    scope.moment,
-    scope.DOMParser,
-    scope.XMLSerializer,
-    scope.atob,
-    scope.btoa,
-    scope.z,
-    scope.$,
-    scope.ErrorException,
-    scope.HaltedException,
-    scope.StopRequestException,
-    scope.ExpiredAuthException,
-    scope.RefreshTokenException,
-    scope.InvalidSessionException
-  );
-
-  return LegacyScriptingRunner(Zap, z, app);
+  return LegacyScriptingRunner(source, z, app);
 };
 
 module.exports = createLegacyScriptingRunner;


### PR DESCRIPTION
Lets `legacy-scripting-runner` compile the legacy scripting source (zapier/zapier-platform-legacy-scripting-runner/pull/10), so we don't have to do it here in `core`.