### PR TITLE
Remove Node 6 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- "6.10.3"
 - "8.10.0"
 - "10"
 notifications:


### PR DESCRIPTION
Looks like we removed Node 6 support from the `cli` package in PR https://github.com/zapier/zapier-platform-cli/pull/328, so there's little reason to keep it here in `core`.