### PR TITLE
Initialize z.legacyScripting for all WB apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4943,9 +4943,9 @@
       "dev": true
     },
     "zapier-platform-schema": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-6.1.0.tgz",
-      "integrity": "sha1-P8Mm2AZvWEdioUHO7RzzQg8iJ30=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-7.0.0.tgz",
+      "integrity": "sha512-oykzhT7FdG93aBniGUHQ83r45WDWEeSCjP4HvyzTIWu2/NT+UQiLEplLV+VqFs2WT+XpWQvbP0hBub7YBOeTww==",
       "requires": {
         "jsonschema": "1.1.1",
         "lodash": "4.17.10"

--- a/src/tools/create-legacy-scripting-runner.js
+++ b/src/tools/create-legacy-scripting-runner.js
@@ -3,9 +3,16 @@
 const path = require('path');
 
 const createLegacyScriptingRunner = (z, app) => {
-  const source = app.legacyScriptingSource;
-  if (!source) {
+  let source = app.legacyScriptingSource;
+  if (source === undefined) {
+    // Don't initialize z.legacyScripting for a pure CLI app
     return null;
+  }
+
+  if (!source) {
+    // Even if the app has no scripting, we still rely on legacy-scripting-runner
+    // to run some scriptingless operations
+    source = 'var Zap = {};';
   }
 
   // Only UI-built app will have this legacy-scripting-runner dependency, so we


### PR DESCRIPTION
The original thought (i.e. the current implementation) was not to pull `legacy-scripting-runner` into `core` (hence `z.legacyScripting` is not available) if the WB app doesn't have scripting. However, this approach requires us to generate JS code in the output app definition, which makes it hard to change the behaviors after the code is generated.

A more flexible approach is allowing all the logic, scripting and scripting-less alike, to happen in `z.legacyScripting.run`. The first step to make it possible is making `z.legacyScripting` available for all converted WB apps, even if the app doesn't have scripting.