### PR TITLE
Upgrade form-data to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1438,12 +1438,12 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
-      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
+        "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
       }
     },
@@ -4943,9 +4943,9 @@
       "dev": true
     },
     "zapier-platform-schema": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-7.0.0.tgz",
-      "integrity": "sha512-oykzhT7FdG93aBniGUHQ83r45WDWEeSCjP4HvyzTIWu2/NT+UQiLEplLV+VqFs2WT+XpWQvbP0hBub7YBOeTww==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-7.1.0.tgz",
+      "integrity": "sha512-nDMQDV85RCRDvQN11m3+5zW/7TMjMj8PJN12MT0lP+7TGMDJU3hcTA/qOluf6fbnhCkHIJyYapglVCnYZ9JJ9Q==",
       "requires": {
         "jsonschema": "1.1.1",
         "lodash": "4.17.10"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bluebird": "3.5.0",
     "content-disposition": "0.5.2",
     "dotenv": "5.0.1",
-    "form-data": "2.2.0",
+    "form-data": "2.3.2",
     "lodash": "4.17.10",
     "node-fetch": "1.7.1",
     "zapier-platform-schema": "7.1.0"


### PR DESCRIPTION
This is the current dependency tree in [legacy-scripting-runner](https://github.com/zapier/zapier-platform-legacy-scripting-runner):

```
$ npm ls form-data
zapier-platform-legacy-scripting-runner@2.1.0
├─┬ request@2.87.0
│ └── form-data@2.3.2
└─┬ zapier-platform-core@7.1.0
  └── form-data@2.2.0
```

This PR upgrades [form-data](https://github.com/form-data/form-data) so that we don't duplicate two versions of form-data.