### PR TITLE
Optimize boilerplate build

### DIFF
--- a/bin/build-boilerplate.sh
+++ b/bin/build-boilerplate.sh
@@ -24,25 +24,21 @@ NEW_VERSION="$(node -p "require('./package.json').version")"
 
 FILE="$BUILD_DIR/$NEW_VERSION.zip"
 
-# Update version
-bin/update-boilerplate-dependencies.js
-
-# Install dependencies
-cd $CONTENTS_DIR && npm install
-
 # Allow pushing "local changes" into the zip file
 if [ "$1" == "--debug" ]; then
-  cp -R ../src/* node_modules/zapier-platform-core/src/
-  cp -R ../node_modules/zapier-platform-legacy-scripting-runner/* node_modules/zapier-platform-legacy-scripting-runner/
-  rm -rf node_modules/zapier-platform-core/node_modules
-  rm -rf node_modules/zapier-platform-legacy-scripting-runner/node_modules
-  rm -rf node_modules/zapier-platform-schema/node_modules
-fi
+  npm pack
+  cd node_modules/zapier-platform-legacy-scripting-runner && npm pack
+  cd ../..
+  bin/update-boilerplate-dependencies.js debug
+  cd $CONTENTS_DIR && npm install
 
-# Build the zip file!
-zip -R ../$FILE '*.js' '*.json'\
-    '*/darwin*node-6/*.node' '*/darwin*node-7/*.node' '*/darwin*node-8/*.node'\
-    '*/linux*node-6/*.node' '*/linux*node-7/*.node' '*/linux*node-8/*.node'
+  zip -R ../$FILE '*.js' '*.json' '*/darwin-x64-node-8/*.node' '*/linux-x64-node-8/*.node'
+else
+  bin/update-boilerplate-dependencies.js
+  cd $CONTENTS_DIR && npm install
+
+  zip -R ../$FILE '*.js' '*.json' '*/linux-x64-node-8/*.node'
+fi
 
 # Revert copied files
 rm -f $FILES_TO_COPY

--- a/bin/update-boilerplate-dependencies.js
+++ b/bin/update-boilerplate-dependencies.js
@@ -3,6 +3,14 @@
 const fs = require('fs');
 const corePackageJson = require('../package.json');
 
+let lsrPackageJson;
+try {
+  // Optional dependency
+  lsrPackageJson = require('../node_modules/zapier-platform-legacy-scripting-runner/package.json');
+} catch (err) {
+  // Do nothing
+}
+
 // Read from ../, write to ./
 const boilerplatePackageJsonPath = './boilerplate/package.json';
 const boilerplateDefinitionJsonPath = './boilerplate/definition.json';
@@ -10,14 +18,38 @@ const boilerplateDefinitionJsonPath = './boilerplate/definition.json';
 const boilerplatePackageJson = require(`.${boilerplatePackageJsonPath}`);
 const boilerplateDefinitionJson = require(`.${boilerplateDefinitionJsonPath}`);
 
-const versionToSet =
-  process.argv.length === 3 && process.argv[2] === 'revert'
-    ? 'CORE_PLATFORM_VERSION'
-    : corePackageJson.version;
+let coreVersionToSet = corePackageJson.version;
+let lsrVersionToSet;
+
+if (process.argv.length === 3) {
+  if (process.argv[2] === 'debug') {
+    coreVersionToSet = `file:../zapier-platform-core-${
+      corePackageJson.version
+    }.tgz`;
+
+    if (lsrPackageJson) {
+      lsrVersionToSet = `file:../node_modules/zapier-platform-legacy-scripting-runner/zapier-platform-legacy-scripting-runner-${
+        lsrPackageJson.version
+      }.tgz`;
+    }
+  } else if (process.argv[2] === 'revert') {
+    coreVersionToSet = 'CORE_PLATFORM_VERSION';
+
+    if (lsrPackageJson) {
+      lsrVersionToSet = lsrPackageJson.version;
+    }
+  }
+}
 
 // Update version
-boilerplatePackageJson.dependencies['zapier-platform-core'] = versionToSet;
-boilerplateDefinitionJson.platformVersion = versionToSet;
+boilerplatePackageJson.dependencies['zapier-platform-core'] = coreVersionToSet;
+boilerplateDefinitionJson.platformVersion = coreVersionToSet;
+
+if (lsrVersionToSet) {
+  boilerplatePackageJson.dependencies[
+    'zapier-platform-legacy-scripting-runner'
+  ] = lsrVersionToSet;
+}
 
 fs.writeFileSync(
   boilerplatePackageJsonPath,


### PR DESCRIPTION
Mainly fixes the following section when we do `./bin/build-boilerplate.sh --debug`:

```
rm -rf node_modules/zapier-platform-core/node_modules
rm -rf node_modules/zapier-platform-legacy-scripting-runner/node_modules
rm -rf node_modules/zapier-platform-schema/node_modules
```

This works fine if all the three packages (`core`, `legacy-scripting-runner`, `schema`) share common dependencies. But if one of them adds a dependency that the others don't rely on, the script generates a broken build.

This PR changes it so that when building a `--debug` boilerplate, we do `npm pack` in `core` and `legacy-scripting-runner` locally. Then we `npm install` those local packages, allowing npm to optimize dependency tree while the code of `core` and `legacy-scripting-runner` is copied from the developer's local machine.