### PR TITLE
Allow to disable SSL certificate check

### DIFF
--- a/src/http-middlewares/before/disable-ssl-cert-check.js
+++ b/src/http-middlewares/before/disable-ssl-cert-check.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const https = require('https');
+
+const disableSSLCertCheck = req => {
+  req.agent = new https.Agent({ rejectUnauthorized: false });
+  return req;
+};
+
+module.exports = disableSSLCertCheck;

--- a/src/http-middlewares/before/disable-ssl-cert-check.js
+++ b/src/http-middlewares/before/disable-ssl-cert-check.js
@@ -3,7 +3,11 @@
 const https = require('https');
 
 const disableSSLCertCheck = req => {
-  req.agent = new https.Agent({ rejectUnauthorized: false });
+  if (req.agent) {
+    req.agent.options.rejectUnauthorized = false;
+  } else {
+    req.agent = new https.Agent({ rejectUnauthorized: false });
+  }
   return req;
 };
 

--- a/src/tools/create-app-request-client.js
+++ b/src/tools/create-app-request-client.js
@@ -11,6 +11,7 @@ const createInjectInputMiddleware = require('../http-middlewares/before/inject-i
 const prepareRequest = require('../http-middlewares/before/prepare-request');
 const addQueryParams = require('../http-middlewares/before/add-query-params');
 const addBasicAuthHeader = require('../http-middlewares/before/add-basic-auth-header');
+const disableSSLCertCheck = require('../http-middlewares/before/disable-ssl-cert-check');
 
 // after middles
 const prepareResponse = require('../http-middlewares/after/prepare-response');
@@ -40,6 +41,11 @@ const createAppRequestClient = (input, options) => {
   }
 
   httpBefores.push(addQueryParams);
+
+  const verify = _.get(input, '_zapier.event.verify');
+  if (verify === false) {
+    httpBefores.push(disableSSLCertCheck);
+  }
 
   const httpOriginalAfters = [prepareResponse, logResponse];
 

--- a/src/tools/create-app-request-client.js
+++ b/src/tools/create-app-request-client.js
@@ -42,8 +42,8 @@ const createAppRequestClient = (input, options) => {
 
   httpBefores.push(addQueryParams);
 
-  const verify = _.get(input, '_zapier.event.verify');
-  if (verify === false) {
+  const verifySSL = _.get(input, '_zapier.event.verifySSL');
+  if (verifySSL === false) {
     httpBefores.push(disableSSLCertCheck);
   }
 

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -357,7 +357,7 @@ describe('request client', () => {
 
   it('should allow to disable SSL certificate check', () => {
     const newInput = _.cloneDeep(input);
-    newInput._zapier.event.verify = false;
+    newInput._zapier.event.verifySSL = false;
     const request = createAppRequestClient(newInput);
     return request('https://self-signed.badssl.com').then(response => {
       response.status.should.eql(200);

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const should = require('should');
-
 const fs = require('fs');
 const path = require('path');
+
+const _ = require('lodash');
+const should = require('should');
 
 const createAppRequestClient = require('../src/tools/create-app-request-client');
 const createInput = require('../src/tools/create-input');
@@ -344,5 +345,22 @@ describe('request client', () => {
         done();
       })
       .catch(done);
+  });
+
+  it('should block self-signed SSL certificate', () => {
+    const request = createAppRequestClient(input);
+    return request('https://self-signed.badssl.com').should.be.rejectedWith({
+      name: 'FetchError',
+      code: 'DEPTH_ZERO_SELF_SIGNED_CERT'
+    });
+  });
+
+  it('should allow to disable SSL certificate check', () => {
+    const newInput = _.cloneDeep(input);
+    newInput._zapier.event.verify = false;
+    const request = createAppRequestClient(newInput);
+    return request('https://self-signed.badssl.com').then(response => {
+      response.status.should.eql(200);
+    });
   });
 });


### PR DESCRIPTION
Addresses https://github.com/zapier/zapier/issues/18677, where the "Disable SSL Certificate Checks" option is not honored by `z.request`.

This PR adds a new before middleware `disableSSLCertCheck` to the `z.request` client if a user checks the "Disable SSL Certificate Checks" in their settings (https://zapier.com/app/settings/advanced).