### PR TITLE
Introduce z.dehydrateFile

### DIFF
--- a/src/app-middlewares/before/z-object.js
+++ b/src/app-middlewares/before/z-object.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 
 const createAppRequestClient = require('../../tools/create-app-request-client');
 const createDehydrator = require('../../tools/create-dehydrator');
+const createFileDehydrator = require('../../tools/create-file-dehydrator');
 const createFileStasher = require('../../tools/create-file-stasher');
 const createJSONtool = require('../../tools/create-json-tool');
 const createStoreKeyTool = require('../../tools/create-storekey-tool');
@@ -22,6 +23,7 @@ const injectZObject = input => {
     JSON: createJSONtool(),
     hash: hashing.hashify,
     dehydrate: createDehydrator(input),
+    dehydrateFile: createFileDehydrator(input),
     stashFile: createFileStasher(input),
     cursor: createStoreKeyTool(input),
     errors

--- a/src/constants.js
+++ b/src/constants.js
@@ -51,6 +51,8 @@ const SAFE_LOG_KEYS = [
   'timestamp'
 ];
 
+const DEFAULT_FILE_HYDRATOR_NAME = 'zapierDefaultFileHydrator';
+
 module.exports = {
   IS_TESTING,
   KILL_MIN_LIMIT,
@@ -62,5 +64,6 @@ module.exports = {
   DEFAULT_LOGGING_HTTP_ENDPOINT,
   DEFAULT_LOGGING_HTTP_API_KEY,
   SENSITIVE_KEYS,
-  SAFE_LOG_KEYS
+  SAFE_LOG_KEYS,
+  DEFAULT_FILE_HYDRATOR_NAME
 };

--- a/src/tools/create-app-request-client.js
+++ b/src/tools/create-app-request-client.js
@@ -51,8 +51,9 @@ const createAppRequestClient = (input, options) => {
 
   if (app.authentication) {
     if (
-      app.authentication.type === 'oauth2' &&
-      _.get(app, 'authentication.oauth2Config.autoRefresh')
+      app.authentication.type === 'session' ||
+      (app.authentication.type === 'oauth2' &&
+        _.get(app, 'authentication.oauth2Config.autoRefresh'))
     ) {
       httpOriginalAfters.push(throwForStaleAuth);
     }

--- a/src/tools/create-dehydrator.js
+++ b/src/tools/create-dehydrator.js
@@ -1,31 +1,9 @@
 'use strict';
 
-const crypto = require('crypto');
-
 const _ = require('lodash');
 
 const resolveMethodPath = require('./resolve-method-path');
-
-const MAX_PAYLOAD_SIZE = 2048; // most urls cannot be larger than 2,083
-
-const wrapHydrate = payload => {
-  payload = JSON.stringify(payload);
-
-  if (process.env._ZAPIER_ONE_TIME_SECRET) {
-    payload = new Buffer(payload).toString('base64');
-
-    const signature = Buffer.from(
-      crypto
-        .createHmac('sha1', process.env._ZAPIER_ONE_TIME_SECRET)
-        .update(payload)
-        .digest()
-    ).toString('base64');
-
-    payload += ':' + signature;
-  }
-
-  return 'hydrate|||' + payload + '|||hydrate';
-};
+const wrapHydrate = require('./wrap-hydrate');
 
 const createDehydrator = input => {
   const app = _.get(input, '_zapier.app');
@@ -35,12 +13,6 @@ const createDehydrator = input => {
     if (inputData.inputData) {
       throw new Error(
         'Oops! You passed a full `bundle` - really you should pass what you want under `inputData`!'
-      );
-    }
-    const payloadSize = JSON.stringify(inputData).length;
-    if (payloadSize > MAX_PAYLOAD_SIZE) {
-      throw new Error(
-        `Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under ${MAX_PAYLOAD_SIZE} bytes (usually by just passing the needed IDs).`
       );
     }
     return wrapHydrate({

--- a/src/tools/create-file-dehydrator.js
+++ b/src/tools/create-file-dehydrator.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const _ = require('lodash');
+
+const { DEFAULT_FILE_HYDRATOR_NAME } = require('../constants');
+const { DehydrateError } = require('../errors');
+const resolveMethodPath = require('./resolve-method-path');
+const wrapHydrate = require('./wrap-hydrate');
+
+const MAX_PAYLOAD_SIZE = 2048; // most urls cannot be larger than 2,083
+
+const createFileDehydrator = input => {
+  const app = _.get(input, '_zapier.app');
+
+  const dehydrateFileFromRequest = (url, request, meta) => {
+    url = url || undefined;
+    request = request || undefined;
+    meta = meta || undefined;
+    if (!url && !request) {
+      throw new DehydrateError(
+        'You must provide either url or request arguments!'
+      );
+    }
+
+    const inputData = {
+      url,
+      request,
+      meta
+    };
+
+    const payloadSize = JSON.stringify(inputData).length;
+    if (payloadSize > MAX_PAYLOAD_SIZE) {
+      throw new DehydrateError(
+        `Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under ${MAX_PAYLOAD_SIZE} bytes (usually by just passing the needed IDs).`
+      );
+    }
+
+    return wrapHydrate({
+      type: 'file',
+      method: `hydrators.${DEFAULT_FILE_HYDRATOR_NAME}`,
+      bundle: inputData
+    });
+  };
+
+  const dehydrateFileFromFunc = (func, inputData) => {
+    inputData = inputData || {};
+    if (inputData.inputData) {
+      throw new DehydrateError(
+        'Oops! You passed a full `bundle` - really you should pass what you want under `inputData`!'
+      );
+    }
+    const payloadSize = JSON.stringify(inputData).length;
+    if (payloadSize > MAX_PAYLOAD_SIZE) {
+      throw new DehydrateError(
+        `Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under ${MAX_PAYLOAD_SIZE} bytes (usually by just passing the needed IDs).`
+      );
+    }
+    return wrapHydrate({
+      type: 'file',
+      method: resolveMethodPath(app, func),
+      // inputData vs. bundle is a legacy oddity
+      bundle: _.omit(inputData, 'environment') // don't leak the environment
+    });
+  };
+
+  return (...args) => {
+    const arg0 = args[0];
+    if (_.isFunction(arg0)) {
+      return dehydrateFileFromFunc.apply(this, args);
+    }
+    if (arg0 && typeof arg0 !== 'string') {
+      throw new DehydrateError(
+        'First argument () must be either null, a URL (string), or a hydrator function!'
+      );
+    }
+    return dehydrateFileFromRequest.apply(this, args);
+  };
+};
+
+module.exports = createFileDehydrator;

--- a/src/tools/create-file-dehydrator.js
+++ b/src/tools/create-file-dehydrator.js
@@ -7,8 +7,6 @@ const { DehydrateError } = require('../errors');
 const resolveMethodPath = require('./resolve-method-path');
 const wrapHydrate = require('./wrap-hydrate');
 
-const MAX_PAYLOAD_SIZE = 2048; // most urls cannot be larger than 2,083
-
 const createFileDehydrator = input => {
   const app = _.get(input, '_zapier.app');
 
@@ -21,24 +19,10 @@ const createFileDehydrator = input => {
         'You must provide either url or request arguments!'
       );
     }
-
-    const inputData = {
-      url,
-      request,
-      meta
-    };
-
-    const payloadSize = JSON.stringify(inputData).length;
-    if (payloadSize > MAX_PAYLOAD_SIZE) {
-      throw new DehydrateError(
-        `Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under ${MAX_PAYLOAD_SIZE} bytes (usually by just passing the needed IDs).`
-      );
-    }
-
     return wrapHydrate({
       type: 'file',
       method: `hydrators.${DEFAULT_FILE_HYDRATOR_NAME}`,
-      bundle: inputData
+      bundle: { url, request, meta }
     });
   };
 
@@ -47,12 +31,6 @@ const createFileDehydrator = input => {
     if (inputData.inputData) {
       throw new DehydrateError(
         'Oops! You passed a full `bundle` - really you should pass what you want under `inputData`!'
-      );
-    }
-    const payloadSize = JSON.stringify(inputData).length;
-    if (payloadSize > MAX_PAYLOAD_SIZE) {
-      throw new DehydrateError(
-        `Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under ${MAX_PAYLOAD_SIZE} bytes (usually by just passing the needed IDs).`
       );
     }
     return wrapHydrate({

--- a/src/tools/create-file-dehydrator.js
+++ b/src/tools/create-file-dehydrator.js
@@ -48,7 +48,7 @@ const createFileDehydrator = input => {
     }
     if (arg0 && typeof arg0 !== 'string') {
       throw new DehydrateError(
-        'First argument () must be either null, a URL (string), or a hydrator function!'
+        `First argument must be either null, a URL (string), or a hydrator function! We got ${typeof arg0}.`
       );
     }
     return dehydrateFileFromRequest.apply(this, args);

--- a/src/tools/create-rpc-client.js
+++ b/src/tools/create-rpc-client.js
@@ -48,7 +48,9 @@ const createRpcClient = event => {
         if (res.content) {
           if (res.content.id !== id) {
             throw new Error(
-              `Got id ${res.content.id} but expected ${id} when calling RPC`
+              `Got id ${res.content.id} but expected ${id} ${
+                res.content
+              } when calling RPC`
             );
           }
           return res.content;

--- a/src/tools/create-rpc-client.js
+++ b/src/tools/create-rpc-client.js
@@ -48,9 +48,7 @@ const createRpcClient = event => {
         if (res.content) {
           if (res.content.id !== id) {
             throw new Error(
-              `Got id ${res.content.id} but expected ${id} ${
-                res.content
-              } when calling RPC`
+              `Got id ${res.content.id} but expected ${id} when calling RPC`
             );
           }
           return res.content;

--- a/src/tools/default-file-hydrator.js
+++ b/src/tools/default-file-hydrator.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const defaultFileHydrator = (z, bundle) => {
+  const request = bundle.inputData.request || {};
+  request.url = bundle.inputData.url || request.url;
+  request.raw = true;
+  const stream = z.request(request);
+  const meta = bundle.inputData.meta || {};
+  return z.stashFile(stream, meta.knownLength, meta.filename, meta.contentType);
+};
+
+module.exports = defaultFileHydrator;

--- a/src/tools/default-file-hydrator.js
+++ b/src/tools/default-file-hydrator.js
@@ -4,9 +4,15 @@ const defaultFileHydrator = (z, bundle) => {
   const request = bundle.inputData.request || {};
   request.url = bundle.inputData.url || request.url;
   request.raw = true;
-  const stream = z.request(request);
+
+  const filePromise = z.request(request);
   const meta = bundle.inputData.meta || {};
-  return z.stashFile(stream, meta.knownLength, meta.filename, meta.contentType);
+  return z.stashFile(
+    filePromise,
+    meta.knownLength,
+    meta.filename,
+    meta.contentType
+  );
 };
 
 module.exports = defaultFileHydrator;

--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const _ = require('lodash');
+
+const { DEFAULT_FILE_HYDRATOR_NAME } = require('../constants');
 const cleaner = require('./cleaner');
 const dataTools = require('./data');
+const defaultFileHydrator = require('./default-file-hydrator');
 const schemaTools = require('./schema-tools');
 const zapierSchema = require('zapier-platform-schema');
 
@@ -98,6 +101,12 @@ const copyPropertiesFromResource = (type, action, appRaw) => {
   return action;
 };
 
+const injectDefaultFileHydrator = appRaw => {
+  appRaw.hydrators = appRaw.hydrators || {};
+  appRaw.hydrators[DEFAULT_FILE_HYDRATOR_NAME] = defaultFileHydrator;
+  return appRaw;
+};
+
 const compileApp = appRaw => {
   appRaw = dataTools.deepCopy(appRaw);
   appRaw = schemaTools.findSourceRequireFunctions(appRaw);
@@ -158,6 +167,8 @@ const compileApp = appRaw => {
       appRaw
     );
   });
+
+  injectDefaultFileHydrator(appRaw);
 
   return appRaw;
 };

--- a/src/tools/wrap-hydrate.js
+++ b/src/tools/wrap-hydrate.js
@@ -2,8 +2,20 @@
 
 const crypto = require('crypto');
 
+const { DehydrateError } = require('../errors');
+
+const MAX_PAYLOAD_SIZE = 2048;
+
 const wrapHydrate = payload => {
   payload = JSON.stringify(payload);
+
+  if (payload.length > MAX_PAYLOAD_SIZE) {
+    throw new DehydrateError(
+      `Oops! You passed too much data (${
+        payload.length
+      } bytes) to your dehydration function - try slimming it down under ${MAX_PAYLOAD_SIZE} bytes (usually by just passing the needed IDs).`
+    );
+  }
 
   if (process.env._ZAPIER_ONE_TIME_SECRET) {
     payload = new Buffer(payload).toString('base64');

--- a/src/tools/wrap-hydrate.js
+++ b/src/tools/wrap-hydrate.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const wrapHydrate = payload => {
+  payload = JSON.stringify(payload);
+
+  if (process.env._ZAPIER_ONE_TIME_SECRET) {
+    payload = new Buffer(payload).toString('base64');
+
+    const signature = Buffer.from(
+      crypto
+        .createHmac('sha1', process.env._ZAPIER_ONE_TIME_SECRET)
+        .update(payload)
+        .digest()
+    ).toString('base64');
+
+    payload += ':' + signature;
+  }
+
+  return 'hydrate|||' + payload + '|||hydrate';
+};
+
+module.exports = wrapHydrate;

--- a/test/create-app.js
+++ b/test/create-app.js
@@ -430,7 +430,6 @@ describe('create-app', () => {
           done('expected an error, got success');
         })
         .catch(error => {
-          debugger;
           error.name.should.eql('RefreshAuthError');
           done();
         });

--- a/test/create-app.js
+++ b/test/create-app.js
@@ -402,6 +402,39 @@ describe('create-app', () => {
           done();
         });
     });
+
+    it('should be applied to session auth app on z.request in functions', done => {
+      const sessionAuthAppDefinition = dataTools.deepCopy(appDefinition);
+      sessionAuthAppDefinition.authentication = {
+        type: 'session',
+        test: {},
+        sessionConfig: {
+          perform: {} // stub, not needed for this test
+        }
+      };
+      const sessionAuthApp = createApp(sessionAuthAppDefinition);
+
+      const event = {
+        command: 'execute',
+        bundle: {
+          inputData: {
+            options: {
+              url: 'http://zapier-httpbin.herokuapp.com/status/401'
+            }
+          }
+        },
+        method: 'resources.executeRequestAsFunc.list.operation.perform'
+      };
+      sessionAuthApp(createInput(sessionAuthAppDefinition, event, testLogger))
+        .then(() => {
+          done('expected an error, got success');
+        })
+        .catch(error => {
+          debugger;
+          error.name.should.eql('RefreshAuthError');
+          done();
+        });
+    });
   });
 
   describe('inputFields', () => {

--- a/test/hydration.js
+++ b/test/hydration.js
@@ -76,6 +76,14 @@ describe('hydration', () => {
       delete process.env._ZAPIER_ONE_TIME_SECRET;
     });
 
+    it('should not allow request as the first argument', () => {
+      (() => {
+        dehydrateFile({ url: 'https://zpr.io/file' });
+      }).should.throw(
+        'First argument must be either null, a URL (string), or a hydrator function! We got object.'
+      );
+    });
+
     it('should not allow missing function', () => {
       const inputData = { key: 'value' };
       (() => {

--- a/test/hydration.js
+++ b/test/hydration.js
@@ -2,10 +2,13 @@
 
 require('should');
 
+const { DEFAULT_FILE_HYDRATOR_NAME } = require('../src/constants');
 const createDehydrator = require('../src/tools/create-dehydrator');
+const createFileDehydrator = require('../src/tools/create-file-dehydrator');
 const funcToFind = () => {};
 const funcToMiss = () => {};
-const dehydrate = createDehydrator({
+
+const input = {
   _zapier: {
     app: {
       some: {
@@ -15,7 +18,10 @@ const dehydrate = createDehydrator({
       }
     }
   }
-});
+};
+
+const dehydrate = createDehydrator(input);
+const dehydrateFile = createFileDehydrator(input);
 
 describe('hydration', () => {
   describe('dehydrate', () => {
@@ -25,26 +31,20 @@ describe('hydration', () => {
 
     it('should not allow orphaned dehydrate', () => {
       const inputData = { key: 'value' };
-      try {
+      (() => {
         dehydrate('foo', inputData);
-        '1'.should.eql('2'); // shouldn't pass
-      } catch (err) {
-        err.message.should.containEql(
-          'You must pass in a function/array/object.'
-        );
-      }
+      }).should.throw(
+        'You must pass in a function/array/object. We got string instead.'
+      );
     });
 
     it('should not allow missing function', () => {
       const inputData = { key: 'value' };
-      try {
+      (() => {
         dehydrate(funcToMiss, inputData);
-        '1'.should.eql('2'); // shouldn't pass
-      } catch (err) {
-        err.message.should.containEql(
-          'We could not find your function/array/object anywhere on your App definition.'
-        );
-      }
+      }).should.throw(
+        'We could not find your function/array/object anywhere on your App definition.'
+      );
     });
 
     it('should deepfind a function on the app', () => {
@@ -56,15 +56,9 @@ describe('hydration', () => {
 
     it('should not accept payload size bigger than 2048 bytes.', () => {
       const inputData = { key: 'a'.repeat(2049) };
-      const payloadSize = JSON.stringify(inputData).length;
-      try {
+      (() => {
         dehydrate(funcToFind, inputData);
-        '1'.should.eql('2'); // shouldn't pass
-      } catch (err) {
-        err.message.should.containEql(
-          `Oops! You passed too much data (${payloadSize} bytes) to your dehydration function - try slimming it down under 2048 bytes (usually by just passing the needed IDs).`
-        );
-      }
+      }).should.throw(/Oops! You passed too much data/);
     });
 
     it('should sign payload', () => {
@@ -73,6 +67,71 @@ describe('hydration', () => {
       const result = dehydrate(funcToFind, inputData);
       result.should.eql(
         'hydrate|||eyJ0eXBlIjoibWV0aG9kIiwibWV0aG9kIjoic29tZS5wYXRoLnRvIiwiYnVuZGxlIjp7ImtleSI6InZhbHVlIn19:Xp29ksdiVvXpnXXA3jXSdA3JkbM=|||hydrate'
+      );
+    });
+  });
+
+  describe('dehydrateFile', () => {
+    afterEach(() => {
+      delete process.env._ZAPIER_ONE_TIME_SECRET;
+    });
+
+    it('should not allow missing function', () => {
+      const inputData = { key: 'value' };
+      (() => {
+        dehydrateFile(funcToMiss, inputData);
+      }).should.throw(
+        'We could not find your function/array/object anywhere on your App definition.'
+      );
+    });
+
+    it('should deepfind a function on the app', () => {
+      const inputData = { key: 'value' };
+      const result = dehydrateFile(funcToFind, inputData);
+      result.should.eql(
+        'hydrate|||{"type":"file","method":"some.path.to","bundle":{"key":"value"}}|||hydrate'
+      );
+    });
+
+    it('should accept url', () => {
+      const result = dehydrateFile('https://zpr.io/file');
+      result.should.eql(
+        `hydrate|||{"type":"file","method":"hydrators.${DEFAULT_FILE_HYDRATOR_NAME}","bundle":{"url":"https://zpr.io/file"}}|||hydrate`
+      );
+    });
+
+    it('should accept url, request, meta', () => {
+      const request = {
+        url: 'https://zpr.io/file',
+        params: { dl: 1 }
+      };
+      const meta = {
+        filename: 'test.txt',
+        contentType: 'text/plain',
+        knownLength: 100
+      };
+      const result = dehydrateFile('https://zpr.io/newfile', request, meta);
+      const expected = {
+        type: 'file',
+        method: `hydrators.${DEFAULT_FILE_HYDRATOR_NAME}`,
+        bundle: { url: 'https://zpr.io/newfile', request, meta }
+      };
+      result.should.eql(`hydrate|||${JSON.stringify(expected)}|||hydrate`);
+    });
+
+    it('should not accept payload size bigger than 2048 bytes.', () => {
+      const inputData = { key: 'a'.repeat(2049) };
+      (() => {
+        dehydrateFile(funcToFind, inputData);
+      }).should.throw(/Oops! You passed too much data/);
+    });
+
+    it('should sign payload', () => {
+      process.env._ZAPIER_ONE_TIME_SECRET = 'super secret';
+      const inputData = { key: 'value' };
+      const result = dehydrateFile(funcToFind, inputData);
+      result.should.eql(
+        'hydrate|||eyJ0eXBlIjoiZmlsZSIsIm1ldGhvZCI6InNvbWUucGF0aC50byIsImJ1bmRsZSI6eyJrZXkiOiJ2YWx1ZSJ9fQ==:5QJ6kP3xyaJu0ENOfrLEIENT6/w=|||hydrate'
       );
     });
   });


### PR DESCRIPTION
Adds `z.dehydrateFile` to CLI. Requires https://github.com/zapier/zapier/pull/19954.

`z.dehydrateFile` has two function signatures:

* `z.dehydrateFile(func, inputData)`: Nothing different from `z.dehydrate(func, inputData)` except that we're annotating the payload with an "it's for a file" tag. So the backend knows not to hydrate it too early in Zap editor.
* `z.dehydrateFile(url, request, meta)`: We'll run `hydrators.zapierDefaultFileHydrator`, which is injected at runtime as part of the app initialization. `zapierDefaultFileHydrator` provides the default implementation for the most common use cases. It downloads the file from the trigger-side app and uploads it to S3 with `z.stashFile`.