### PR TITLE
fix null error handling

### DIFF
--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -169,10 +169,10 @@ const createLambdaHandler = appRawOrPath => {
       // the default behavior with callbacks anyway, but don't want
       // to rely on that.
       logger(logMsg, logData).then(() => {
-        if (!constants.IS_TESTING) {
-          err.message +=
-            '\n\nConsole logs:\n' +
-            logBuffer.map(s => `  ${s.message}`).join('');
+        if (!constants.IS_TESTING && err) {
+          err.message += `\n\nConsole logs:\n${logBuffer
+            .map(s => `  ${s.message}`)
+            .join('')}`;
         }
         callbackOnce(err);
       });
@@ -181,7 +181,8 @@ const createLambdaHandler = appRawOrPath => {
     const handlerDomain = domain.create();
 
     handlerDomain.on('error', err => {
-      const logMsg = `Uncaught error: ${err}\n${err.stack || '<stack>'}`;
+      const logMsg = `Uncaught error: ${err}\n${(err && err.stack) ||
+        '<stack>'}`;
       const logData = { err, log_type: 'error' };
       logErrorAndCallbackOnce(logMsg, logData, err);
     });
@@ -208,7 +209,8 @@ const createLambdaHandler = appRawOrPath => {
           callbackOnce(null, cleaner.maskOutput(output));
         })
         .catch(err => {
-          const logMsg = `Unhandled error: ${err}\n${err.stack || '<stack>'}`;
+          const logMsg = `Unhandled error: ${err}\n${(err && err.stack) ||
+            '<stack>'}`;
           const logData = { err, log_type: 'error' };
           logErrorAndCallbackOnce(logMsg, logData, err);
         });


### PR DESCRIPTION
Fixes https://github.com/zapier/zapier/issues/18163. 

If a user calls `Promise.reject(null)` in a somewhere, it bubbles to here and causes a further error. This _should_ fix it

I'm not sure how to test this - I would think that it's in `integration-test`, but adding a test that looks a lot like [this](https://github.com/zapier/zapier-platform-core/blob/cc3b6381d098203490deb5714e23c85125a29dd8/test/userapp/index.js#L258-L272) didn't seem to trip like i thought it would. Any ideas would be appreciated!