### PR TITLE
Fix default file hydrator

### DIFF
--- a/src/tools/default-file-hydrator.js
+++ b/src/tools/default-file-hydrator.js
@@ -1,11 +1,17 @@
 'use strict';
 
-const defaultFileHydrator = (z, bundle) => {
-  const request = bundle.inputData.request || {};
-  request.url = bundle.inputData.url || request.url;
-  request.raw = true;
+const _ = require('lodash');
 
-  const filePromise = z.request(request);
+const requestInternal = require('./request-client-internal');
+
+const defaultFileHydrator = (z, bundle) => {
+  const requestOptions = bundle.inputData.request || {};
+  const request = _.isEmpty(requestOptions) ? z.request : requestInternal;
+
+  requestOptions.url = bundle.inputData.url || requestOptions.url;
+  requestOptions.raw = true;
+
+  const filePromise = request(requestOptions);
   const meta = bundle.inputData.meta || {};
   return z.stashFile(
     filePromise,

--- a/test/tools/default-file-hydrator.js
+++ b/test/tools/default-file-hydrator.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const defaultFileHydrator = require('../../src/tools/default-file-hydrator');
+const requestInternal = require('../../src/tools/request-client-internal');
+
+describe('default file hydrator', () => {
+  // Mocked z object
+  const z = {
+    request: options => {
+      options.headers = options.headers || {};
+      options.headers['X-Footprint'] = 'a proof that z.request is used';
+      return requestInternal(options);
+    },
+
+    stashFile: (responsePromise, knownLength, filename, contentType) =>
+      responsePromise.then(response => {
+        // Instead of returning a URL, like how real z.stashFile does, here we make
+        // z.stashFile return all the useful info for testing
+        return {
+          response,
+          knownLength,
+          filename,
+          contentType
+        };
+      })
+  };
+
+  it('should use z.request', () => {
+    const bundle = {
+      inputData: {
+        url: 'https://zapier-httpbin.herokuapp.com/get'
+      }
+    };
+    return defaultFileHydrator(z, bundle).then(result => {
+      const content = result.response.content;
+      content.headers['X-Footprint'].should.eql(
+        'a proof that z.request is used'
+      );
+    });
+  });
+
+  it('should use internal request client', () => {
+    const bundle = {
+      inputData: {
+        url: 'https://zapier-httpbin.herokuapp.com/get',
+        request: {
+          headers: { 'X-Foo': 'hello' }
+        }
+      }
+    };
+    return defaultFileHydrator(z, bundle).then(result => {
+      const content = result.response.content;
+      content.headers.should.not.have.property('X-Footprint');
+      content.headers['X-Foo'].should.eql('hello');
+    });
+  });
+
+  it('should pass along file meta', () => {
+    const bundle = {
+      inputData: {
+        url: 'https://zapier-httpbin.herokuapp.com/get',
+        meta: {
+          knownLength: 1234,
+          filename: 'hello.json',
+          contentType: 'application/json'
+        }
+      }
+    };
+    return defaultFileHydrator(z, bundle).then(result => {
+      const content = result.response.content;
+      content.headers['X-Footprint'].should.eql(
+        'a proof that z.request is used'
+      );
+
+      result.knownLength.should.eql(1234);
+      result.filename.should.eql('hello.json');
+      result.contentType.should.eql('application/json');
+    });
+  });
+});

--- a/test/userapp/index.js
+++ b/test/userapp/index.js
@@ -496,6 +496,10 @@ const changeStatusOnErrorResponses = response => {
     return response;
   }
 
+  if (response.request.raw) {
+    return response;
+  }
+
   const data = JSON.parse(response.content);
   const error = data.args.error;
   if (response.status === 200 && error) {


### PR DESCRIPTION
## Background

Default File Hydrator is a function that we inject to the app definition at runtime. It was added in PR #112 to power the newly-introduced `z.dehydrateFile` method. When a dev calls `z.dehydrateFile(url, request, meta)`, they're doing `z.dehydrateFile(hydrators.zapierDefaultHydrator, { url, request, meta })` essentially.

## What This PR Fixes

The `request` and `meta` argument in `z.dehydrateFile(url, request, meta)` are optional. When a dev omits `request` argument, i.e., `z.dehydrateFile(url)`, we should include the user's auth info when we make the request to `url`. On the other hand, if `request` argument is provided, we should **not** include the user's auth info. This is to make the behavior consistent with the Web Builder as described in this [doc](https://zapier.com/developer/documentation/v2/scripting/#dehydrating-files).

There's a doc change in PR https://github.com/zapier/zapier-platform-cli/pull/360 you may want to take a look at: https://github.com/zapier/zapier-platform-cli/pull/360/commits/ff79a0492fe7634f7ce6e18cab182535b8acc22a.