### PR TITLE
Add Support for App Middlewares

### DIFF
--- a/src/create-app.js
+++ b/src/create-app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const applyMiddleware = require('./middleware');
+const ensureArray = require('./tools/ensure-array');
 const schemaTools = require('./tools/schema');
 
 // before middles
@@ -24,10 +25,16 @@ const createApp = appRaw => {
   const frozenCompiledApp = schemaTools.prepareApp(appRaw);
 
   // standard before middlewares
-  const befores = [addAppContext, injectZObject];
+  const befores = [addAppContext, injectZObject].concat(
+    ensureArray(frozenCompiledApp.beforeApp)
+  );
 
   // standard after middlewares
-  const afters = [checkOutput, largeResponseCachePointer, waitForPromises];
+  const afters = [
+    checkOutput,
+    largeResponseCachePointer,
+    waitForPromises
+  ].concat(ensureArray(frozenCompiledApp.afterApp));
 
   const app = createCommandHandler(frozenCompiledApp);
   return applyMiddleware(befores, afters, app);

--- a/src/create-app.js
+++ b/src/create-app.js
@@ -25,16 +25,19 @@ const createApp = appRaw => {
   const frozenCompiledApp = schemaTools.prepareApp(appRaw);
 
   // standard before middlewares
-  const befores = [addAppContext, injectZObject].concat(
-    ensureArray(frozenCompiledApp.beforeApp)
-  );
+  const befores = [
+    addAppContext,
+    injectZObject,
+    ...ensureArray(frozenCompiledApp.beforeApp)
+  ];
 
   // standard after middlewares
   const afters = [
     checkOutput,
     largeResponseCachePointer,
-    waitForPromises
-  ].concat(ensureArray(frozenCompiledApp.afterApp));
+    waitForPromises,
+    ...ensureArray(frozenCompiledApp.afterApp)
+  ];
 
   const app = createCommandHandler(frozenCompiledApp);
   return applyMiddleware(befores, afters, app);

--- a/test/app-middleware.js
+++ b/test/app-middleware.js
@@ -19,7 +19,7 @@ describe('app middleware', () => {
     const appDefinition = dataTools.deepCopy(exampleAppDefinition);
     appDefinition.beforeApp = [
       input => {
-        // We swap up the invocation to run a real method
+        // Swap up context to point to a real method
         input._zapier.event.method = 'resources.list.list.operation.perform';
         return input;
       }
@@ -27,6 +27,7 @@ describe('app middleware', () => {
     const app = createApp(appDefinition);
 
     // Create the input to point to a non-existent method on the app
+    // the before middleware is gonna re-route this to a real method
     const input = createTestInput(
       'something.that.does.not.exist',
       appDefinition
@@ -50,7 +51,8 @@ describe('app middleware', () => {
     ];
     const app = createApp(appDefinition);
 
-    // Create the input to point to a non-existent method on the app
+    // We are gonna invoke this method, but the after middleware is gonna
+    // change the result returned to something else
     const input = createTestInput(
       'resources.list.list.operation.perform',
       appDefinition

--- a/test/app-middleware.js
+++ b/test/app-middleware.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const createApp = require('../src/create-app');
+const createInput = require('../src/tools/create-input');
+const dataTools = require('../src/tools/data');
+const exampleAppDefinition = require('./userapp');
+
+describe('app middleware', () => {
+  const createTestInput = (method, appDefinition) => {
+    const event = {
+      bundle: {},
+      method
+    };
+
+    return createInput(appDefinition, event);
+  };
+
+  it('should support before middleware', done => {
+    const appDefinition = dataTools.deepCopy(exampleAppDefinition);
+    appDefinition.beforeApp = [
+      input => {
+        // We swap up the invocation to run a real method
+        input._zapier.event.method = 'resources.list.list.operation.perform';
+        return input;
+      }
+    ];
+    const app = createApp(appDefinition);
+
+    // Create the input to point to a non-existent method on the app
+    const input = createTestInput(
+      'something.that.does.not.exist',
+      appDefinition
+    );
+
+    app(input)
+      .then(output => {
+        output.results.should.eql([{ id: 1234 }, { id: 5678 }]);
+        done();
+      })
+      .catch(done);
+  });
+
+  it('should support after middleware', done => {
+    const appDefinition = dataTools.deepCopy(exampleAppDefinition);
+    appDefinition.afterApp = [
+      output => {
+        output.results = [{ id: 'something new' }];
+        return output;
+      }
+    ];
+    const app = createApp(appDefinition);
+
+    // Create the input to point to a non-existent method on the app
+    const input = createTestInput(
+      'resources.list.list.operation.perform',
+      appDefinition
+    );
+
+    app(input)
+      .then(output => {
+        output.results.should.eql([{ id: 'something new' }]);
+        done();
+      })
+      .catch(done);
+  });
+});


### PR DESCRIPTION
We designed core to be able to do this, but never added it. Check out [this code comment](https://github.com/zapier/zapier-platform-core/blob/050654422338db4aa165e17b11e0fddc1c253453/src/create-app.js#L20-L21).

This requires https://github.com/zapier/zapier-platform-schema/pull/56 as well.