### PR TITLE
Pass `input` to legacy-scripting-runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4980,9 +4980,9 @@
       "dev": true
     },
     "zapier-platform-schema": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-7.2.2.tgz",
-      "integrity": "sha512-EzIvCuEZW+tf20lfRE29CEZZ4tshL4HTkCld1QiAz8zcZaw7h6lwSDufC/PsC1Wr8Oa7v2JZEV0RGvBIbOHQew==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-7.3.0.tgz",
+      "integrity": "sha512-VNYXTjHCl4qMrkQP+jvyCjVXyitQmWxDPHQNLzhszEabSxbJLVXY5WNIFCOwf+ybdvPwS8YVZ5uXRDRuTBKi8A==",
       "requires": {
         "jsonschema": "1.1.1",
         "lodash": "4.17.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,7 +397,7 @@
     },
     "babel-eslint": {
       "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
       "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
       "dev": true,
       "requires": {
@@ -4100,10 +4100,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "form-data": "2.3.2",
     "lodash": "4.17.10",
     "node-fetch": "1.7.1",
+    "semver": "5.6.0",
     "zapier-platform-schema": "7.2.2"
   },
   "devDependencies": {

--- a/src/app-middlewares/before/z-object.js
+++ b/src/app-middlewares/before/z-object.js
@@ -34,8 +34,7 @@ const injectZObject = input => {
     request: createAppRequestClient(input, { extraArgs: [zSkinny, bundle] })
   });
 
-  const app = _.get(input, '_zapier.app');
-  const runner = createLegacyScriptingRunner(z, app);
+  const runner = createLegacyScriptingRunner(z, input);
   if (runner) {
     z.legacyScripting = runner;
   }


### PR DESCRIPTION
Would like to pass `input` to `LegacyScriptingRunner` so we can be more flexible there. Currently, we create it by passing `(source, z, app)`. This PR extends it so that when `zapier-platform-legacy-scripting-runner >= 3.0.0` is installed, we pass `(source, z, input)` to it. This relevant change on the other side is in https://github.com/zapier/zapier-platform-legacy-scripting-runner/pull/24.