### PR TITLE
Fix bug: z.stashFile doesn't pick up filename in Content-Disposition

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "preversion": "git pull && npm test",
     "version": "node bin/bump-dependencies.js && git add package.json",
     "postversion": "git push && git push --tags",
-    "test": "mocha -t 5000 --recursive test",
+    "test": "mocha -t 10000 --recursive test",
     "posttest": "npm run lint",
     "plain-test": "mocha -t 5000 --recursive test",
     "integration-test": "mocha -t 10000 integration-test",

--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -226,4 +226,32 @@ describe('file upload', () => {
       })
       .catch(done);
   });
+
+  it('should get filename from content-disposition', done => {
+    mocky.mockRpcCall(mocky.fakeSignedPostData);
+
+    // Expect to have this part in the request body sent to S3
+    mocky.mockUpload(
+      /name="Content-Disposition"\r\n\r\nattachment; filename="an example\.json"/
+    );
+
+    const request = createAppRequestClient(input);
+    const file = request({
+      url: 'https://zapier-httpbin.herokuapp.com/response-headers',
+      params: {
+        'Content-Disposition': 'inline; filename="an example.json"'
+      },
+      raw: true
+    });
+    stashFile(file)
+      .then(url => {
+        should(url).eql(
+          `${mocky.fakeSignedPostData.url}${
+            mocky.fakeSignedPostData.fields.key
+          }`
+        );
+        done();
+      })
+      .catch(done);
+  });
 });

--- a/test/tools/mocky.js
+++ b/test/tools/mocky.js
@@ -39,9 +39,9 @@ const fakeSignedPostData = {
   }
 };
 
-const mockUpload = () => {
+const mockUpload = bodyMatcher => {
   nock('http://s3-fake.zapier.com')
-    .post('/')
+    .post('/', bodyMatcher)
     .reply(204, '');
 };
 


### PR DESCRIPTION
Fixes https://github.com/zapier/zapier/issues/14350.

Quoted from the issue:

> Developer uses z.stashFile() but when another actions consumes the file (or downloads from the returned S3 URL) it comes with the default unnamedfile filename and not the filename the URL passed to z.stashFile() is sending in the disposition.