### PR TITLE
(fix) cursor reading didn't work in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,7 +397,7 @@
     },
     "babel-eslint": {
       "version": "8.2.3",
-      "resolved": "http://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.3.tgz",
       "integrity": "sha512-0HeSTtaXg/Em7FCUWxwOT+KeFSO1O7LuRuzhk7g+1BjwdlQGlHq4OyMi3GqGxrNfEq8jEi6Hmt5ylEQUhurgiQ==",
       "dev": true,
       "requires": {
@@ -4163,7 +4163,7 @@
     },
     "should-equal": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
       "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
       "dev": true,
       "requires": {

--- a/src/http-middlewares/before/add-digest-auth-header.js
+++ b/src/http-middlewares/before/add-digest-auth-header.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const crypto = require('crypto');
 const urllib = require('url');
-
 const fetch = require('node-fetch');
 
 const { NotImplementedError } = require('../../errors');
+const { md5 } = require('../../tools/data');
 
 // This function splits a comma-separated string described by RFC 2068 Section 2.
 // Ported from https://github.com/python/cpython/blob/f081fd83/Lib/urllib/request.py#L1399-L1440
@@ -79,12 +78,6 @@ const parseDictHeader = s => {
 
   return res;
 };
-
-const md5 = s =>
-  crypto
-    .createHash('md5')
-    .update(s)
-    .digest('hex');
 
 const buildDigestHeader = (username, password, url, method, creds) => {
   if (creds.algorithm && creds.algorithm.toUpperCase() !== 'MD5') {

--- a/src/http-middlewares/before/add-digest-auth-header.js
+++ b/src/http-middlewares/before/add-digest-auth-header.js
@@ -4,7 +4,7 @@ const urllib = require('url');
 const fetch = require('node-fetch');
 
 const { NotImplementedError } = require('../../errors');
-const { md5 } = require('../../tools/data');
+const { md5 } = require('../../tools/hashing');
 
 // This function splits a comma-separated string described by RFC 2068 Section 2.
 // Ported from https://github.com/python/cpython/blob/f081fd83/Lib/urllib/request.py#L1399-L1440

--- a/src/tools/create-app-tester.js
+++ b/src/tools/create-app-tester.js
@@ -4,7 +4,7 @@ const createLambdaHandler = require('./create-lambda-handler');
 const resolveMethodPath = require('./resolve-method-path');
 const ZapierPromise = require('./promise');
 const { get } = require('lodash');
-const { genId } = require('./data');
+const { md5 } = require('./data');
 
 // this is (annoyingly) mirrored in cli/api_base, so that test functions only
 // have a storeKey when canPaginate is true. otherwise, a test would work but a
@@ -45,11 +45,15 @@ const createAppTester = appRaw => {
 
     const method = resolveMethodPath(appRaw, methodOrFunc);
 
+    // we need a value that's unique to this test (but consistent across test runs) so we don't lose cursors
+    const username = process.env.USER || process.env.USERNAME || 'fallback';
+    const unique = md5(`${method}-${username}`);
+
     const event = {
       command: 'execute',
       method,
       bundle,
-      storeKey: shouldPaginate(appRaw, method) ? `testKey-${genId()}` : null
+      storeKey: shouldPaginate(appRaw, method) ? `testKey-${unique}` : null
     };
 
     if (process.env.LOG_TO_STDOUT) {

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const memoize = require('./memoize');
 const plainModule = require('./plain');
-const crypto = require('crypto');
 
 const isPlainObj = o => {
   return (
@@ -174,12 +173,6 @@ const simpleTruncate = (string, length, suffix) => {
 
 const genId = () => parseInt(Math.random() * 100000000);
 
-const md5 = s =>
-  crypto
-    .createHash('md5')
-    .update(s)
-    .digest('hex');
-
 module.exports = {
   deepCopy,
   deepFreeze,
@@ -188,7 +181,6 @@ module.exports = {
   genId,
   isPlainObj,
   jsonCopy,
-  md5,
   memoizedFindMapDeep,
   recurseExtract,
   recurseReplace,

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const memoize = require('./memoize');
 const plainModule = require('./plain');
+const crypto = require('crypto');
 
 const isPlainObj = o => {
   return (
@@ -173,16 +174,23 @@ const simpleTruncate = (string, length, suffix) => {
 
 const genId = () => parseInt(Math.random() * 100000000);
 
+const md5 = s =>
+  crypto
+    .createHash('md5')
+    .update(s)
+    .digest('hex');
+
 module.exports = {
-  isPlainObj,
-  findMapDeep,
-  memoizedFindMapDeep,
   deepCopy,
-  jsonCopy,
   deepFreeze,
-  recurseReplace,
-  recurseExtract,
+  findMapDeep,
   flattenPaths,
-  simpleTruncate,
-  genId
+  genId,
+  isPlainObj,
+  jsonCopy,
+  md5,
+  memoizedFindMapDeep,
+  recurseExtract,
+  recurseReplace,
+  simpleTruncate
 };

--- a/src/tools/hashing.js
+++ b/src/tools/hashing.js
@@ -22,7 +22,14 @@ const snipify = s => {
   return `:censored:${length}:${result.substr(0, 10)}:`;
 };
 
+const md5 = s =>
+  crypto
+    .createHash('md5')
+    .update(s)
+    .digest('hex');
+
 module.exports = {
   hashify,
+  md5,
   snipify
 };


### PR DESCRIPTION
We were having an issue where cursors mostly didn't work in unit tests at all. 

### How it's supposed to work

When run as part of a zap, the server sends a `storeKey` that always points to the data that individual zap has previously saved (based on the node id). The most common pattern is that the first run sets a cursor and subsequent runs read that cursor, make a call, and set an updated cursor.

### The problem 

When running unit tests with a cursor, there isn't a node. Instead, we generated a random id so that multiple users wouldn't be fighting over keyspace. The issue is that separate invocations of `appTest(App...)` would create new random ids. Tests would write data to `testKey-123` and then try to read from `testKey-456` which was blank, causing the tests to fail.

### The solution

The issue we're trying to avoid flaky tests caused by key collisions. If everyone's cursor wrote to `key-cursor-test`, then multiple people running tests within the same 60-second window (globally) would lead to weird behavior. 

The first solution was using the method, but given that we rely so heavily on scaffolds and triggers like `recipe`, I was concerned we'd still have collisions. I wanted to use something unique to the user. Ideally we could use the `app_id`, but that doesn't always exist (eg: a new app), so username felt like a reasonable fallback. I felt weird about sending user's usernames to our server, so I figured hashing it was the best way to have the best of both worlds. Not perfect (there are still collisions on a per-user and per-method basis), but close enough.

### Testing
Addresses [PDE-273](https://zapierorg.atlassian.net/browse/PDE-273)

I tested by linking core, and using the following trigger and test:

```js
// recipe.js
const _ = require('lodash')

const randomStr = () =>
  Math.random()
    .toString(36)
    .slice(2)

// triggers on recipe with a certain tag
const triggerRecipe = async (z, bundle) => {
  const cursor = _.get(bundle, 'meta.page') ? await z.cursor.get() : null

  console.log('starting with', cursor)
  const newCursor = randomStr()
  await z.cursor.set(newCursor)

  return [{ id: 1, old: cursor, new: newCursor }]
}

module.exports = {
  key: 'recipe',
  noun: 'Recipe',

  display: {
    label: 'Get Recipe',
    description: 'Triggers on a new recipe.'
  },

  operation: {
    canPaginate: true,
    perform: triggerRecipe,

    sample: {
      id: 1
    }
  }
}
```

```js
// test.js

it('should run triggers.recipe', async () => {
    const results = await appTester(App.triggers.recipe.operation.perform, {})
    console.log('results', results)
    should.exist(results)
    should(results[0].old).equal(null)
    should.exist(results[0].new)

    const results2 = await appTester(App.triggers.recipe.operation.perform, {
      meta: { page: 1 }
    })
    console.log('results', results2)
    should(results2[0].old).not.equal(null)
    should.exist(results2[0].new)

    results2[0].new.should.not.equal(results[0].new)
  })
```