### PR TITLE
Update schema version in package-lock.json before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "preversion": "git pull && npm test",
-    "version": "node bin/bump-dependencies.js && git add package.json",
+    "version": "node bin/bump-dependencies.js && npm install && git add package.json package-lock.json",
     "postversion": "git push && git push --tags",
     "test": "mocha -t 10000 --recursive test",
     "posttest": "npm run lint",


### PR DESCRIPTION
Fixes a small annoyance where Travis fails on Node 10.x, like this [build](https://travis-ci.org/zapier/zapier-platform-core/builds/430014171). This is because Travis runs `npm ci` (instead of `npm install`), which uses `package-lock.json` (instead of `package.json`), to install dependencies. And the [script](https://github.com/zapier/zapier-platform-core/blob/d9edbf30546b1597a61b6119c4a558195b013de8/bin/bump-dependencies.js) we use to bump schema version only updates `package.json`, leaving `package-lock.json` intact. To fix it, we only need to run `npm install` after we bump the schema version in `package.json`.