### PR TITLE
(fix) make sure to censor url encoded values

### DIFF
--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -67,7 +67,7 @@ const makeSensitiveBank = (event, data) => {
   );
 
   const matcher = (key, value) => {
-    if (typeof value === 'string') {
+    if (_.isString(value)) {
       const lowerKey = key.toLowerCase();
       return _.some(constants.SENSITIVE_KEYS, k => lowerKey.indexOf(k) >= 0);
     }
@@ -84,7 +84,9 @@ const makeSensitiveBank = (event, data) => {
       // keeps short values from spamming censor strings in logs, < 6 chars is not a proper secret
       // see https://github.com/zapier/zapier-platform-core/issues/4#issuecomment-277855071
       if (val && String(val).length > 5) {
-        bank[val] = hashing.snipify(val);
+        const censored = hashing.snipify(val);
+        bank[val] = censored;
+        bank[encodeURIComponent(val)] = censored;
       }
       return bank;
     },

--- a/test/logger.js
+++ b/test/logger.js
@@ -2,6 +2,7 @@
 
 require('should');
 const createlogger = require('../src/tools/create-logger');
+const querystring = require('querystring');
 
 describe('logger', () => {
   const options = {
@@ -79,7 +80,8 @@ describe('logger', () => {
     const bundle = {
       authData: {
         password: 'secret',
-        key: 'notell'
+        key: 'notell',
+        api_key: 'pa$$word'
       }
     };
     const logger = createlogger({ bundle }, options);
@@ -88,7 +90,10 @@ describe('logger', () => {
       response_content: `{
         "something": "secret",
         "somethingElse": "notell",
-      }`
+      }`,
+      request_url: `https://test.com/?${querystring.stringify({
+        api_key: 'pa$$word'
+      })}`
     };
 
     return logger('test', data).then(response => {
@@ -101,6 +106,7 @@ describe('logger', () => {
         "something": ":censored:6:a5023f748d:",
         "somethingElse": ":censored:6:8f63f9ff57:",
       }`,
+          request_url: 'https://test.com/?api_key=:censored:8:f274744218:',
           log_type: 'console'
         }
       });


### PR DESCRIPTION
matches https://github.com/zapier/lambda-wrapper/pull/32 and a while ago. While this wasn't a reported issue here, figure we cover all our bases. See also: https://github.com/zapier/zapier/issues/21418