### PR TITLE
Fix boilerplate upload

### DIFF
--- a/bin/upload-boilerplate.sh
+++ b/bin/upload-boilerplate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 BUCKET='zapier-dev-platform-cli-boilerplates'
-
-aws s3 cp ./build-boilerplate/$TRAVIS_TAG.zip s3://$BUCKET/$TRAVIS_TAG.zip --acl public-read
+TAG_WITHOUT_V=${TRAVIS_TAG:1}
+aws s3 cp ./build-boilerplate/$TAG_WITHOUT_V.zip s3://$BUCKET/$TAG_WITHOUT_V.zip --acl public-read


### PR DESCRIPTION
The `upload-boilerplate.zip` failed because `$TRAVIS_TAG` starts with a `v`. Find the error message in this build: https://travis-ci.org/zapier/zapier-platform-core/jobs/457833836#L2527.