### PR TITLE
Re-org legacy scripting source

### DIFF
--- a/src/app-middlewares/before/z-object.js
+++ b/src/app-middlewares/before/z-object.js
@@ -38,7 +38,7 @@ const injectZObject = input => {
 
   const runner = createLegacyScriptingRunner(z, input);
   if (runner) {
-    z.legacyScripting = runner;
+    z.legacyScripting = zSkinny.legacyScripting = runner;
   }
 
   return _.extend({}, input, { z });

--- a/src/tools/create-legacy-scripting-runner.js
+++ b/src/tools/create-legacy-scripting-runner.js
@@ -8,7 +8,8 @@ const semver = require('semver');
 const createLegacyScriptingRunner = (z, input) => {
   const app = _.get(input, '_zapier.app');
 
-  let source = app.legacyScriptingSource;
+  let source =
+    _.get(app, 'legacy.scriptingSource') || app.legacyScriptingSource;
   if (source === undefined) {
     // Don't initialize z.legacyScripting for a pure CLI app
     return null;


### PR DESCRIPTION
Addresses [PDE-538](https://zapierorg.atlassian.net/browse/PDE-538). This allows legacy apps to put scripting source at `.legacy.scriptingSource` in the app definition. The change is backward compatible; the old location `.legacyScriptingSource` will still work.