### PR TITLE
Allow to skip specific output checks

### DIFF
--- a/src/app-middlewares/after/checks.js
+++ b/src/app-middlewares/after/checks.js
@@ -19,10 +19,15 @@ const checkOutput = output => {
   const runChecks =
     event.method && event.command === 'execute' && !_zapier.skipChecks;
 
+  const bundleSkipChecks = event.bundle.skipChecks || [];
+
   if (runChecks) {
     const rawResults = checks
       .filter(check => {
-        return check.shouldRun(event.method, event.bundle);
+        return (
+          !bundleSkipChecks.includes(check.name) &&
+          check.shouldRun(event.method, event.bundle)
+        );
       })
       .map(check => {
         return check

--- a/test/checks.js
+++ b/test/checks.js
@@ -3,6 +3,7 @@
 require('should');
 
 const checks = require('../src/checks');
+const checkOutput = require('../src/app-middlewares/after/checks');
 
 const isTrigger = require('../src/checks/is-trigger');
 const isSearch = require('../src/checks/is-search');
@@ -83,5 +84,46 @@ describe('checks', () => {
     isCreate('creates.blah.operation.perform').should.be.true();
     isCreate('resources.blah.create.operation.perform').should.be.true();
     isCreate('blah').should.be.false();
+  });
+});
+
+describe('checkOutput', () => {
+  it('should ensure trigger has id', () => {
+    const output = {
+      input: {
+        _zapier: {
+          event: {
+            method: 'triggers.key.operation.perform',
+            command: 'execute',
+            bundle: {}
+          }
+        }
+      },
+      results: [{ text: 'An item without id' }]
+    };
+
+    (() => {
+      checkOutput(output);
+    }).should.throw(/missing the "id"/);
+  });
+
+  it('should allow to skip checks', () => {
+    const output = {
+      input: {
+        _zapier: {
+          event: {
+            method: 'triggers.key.operation.perform',
+            command: 'execute',
+            bundle: {
+              skipChecks: ['triggerHasId']
+            }
+          }
+        }
+      },
+      results: [{ text: 'An item without id' }]
+    };
+
+    const newOutput = checkOutput(output);
+    newOutput.should.deepEqual(output);
   });
 });


### PR DESCRIPTION
Addresses https://github.com/zapier/zapier/pull/22029#pullrequestreview-184255463. Instead of using a hack to bypass the trigger id check, this PR allows devs to use `bundle.skipChecks` to skip certain output checks in core. To skip `triggerHasId` check, for example, the dev would set `bundle.skipChecks` to `['triggerHasId']`.