### PR TITLE
(fix) don't search-or-create if either is hidden

### DIFF
--- a/src/tools/schema.js
+++ b/src/tools/schema.js
@@ -7,6 +7,8 @@ const dataTools = require('./data');
 const schemaTools = require('./schema-tools');
 const zapierSchema = require('zapier-platform-schema');
 
+const isVisible = action => !_.get(action, ['display', 'hidden']);
+
 // Take a resource with methods like list/hook and turn it into triggers, etc.
 const convertResourceDos = appRaw => {
   let triggers = {},
@@ -51,13 +53,13 @@ const convertResourceDos = appRaw => {
       creates[create.key] = create;
     }
 
-    if (search && create) {
-      let searchOrCreate = {
+    if (search && create && isVisible(search) && isVisible(create)) {
+      const searchOrCreate = {
         //key: `${resource.key}SearchOrCreate`,
         key: `${search.key}`, // For now this is a Zapier editor limitation (has to match search)
         display: {
           label: `Find or Create ${resource.noun}`,
-          description: (search.display && search.display.description) || ''
+          description: _.get(search, ['display', 'description'], '')
         },
         search: search.key,
         create: create.key

--- a/test/tools/schema.js
+++ b/test/tools/schema.js
@@ -134,6 +134,54 @@ describe('schema', () => {
       });
     });
 
+    it('should not make a searchOrCreate if either is hidden', () => {
+      const dummySearch = {
+        display: {
+          label: 'Find a Foo',
+          description: 'Finds a Foo.'
+        },
+        operation: {
+          perform: () => {
+            return {};
+          }
+        }
+      };
+
+      const dummyCreate = {
+        display: {
+          label: 'Create a Foo',
+          description: 'Creates a Foo.',
+          hidden: true
+        },
+        operation: {
+          perform: () => {
+            return {};
+          }
+        }
+      };
+
+      const appRaw = {
+        resources: {
+          foo: {
+            key: 'foo',
+            noun: 'Foo',
+            search: dummySearch,
+            create: dummyCreate,
+            outputFields: [
+              { key: 'id', type: 'integer' },
+              { key: 'name', type: 'string' }
+            ],
+            sample: {
+              id: 123,
+              name: 'John Doe'
+            }
+          }
+        }
+      };
+      const compiledApp = schema.compileApp(appRaw);
+      compiledApp.searchOrCreates.should.deepEqual({});
+    });
+
     it("should populate hook's performList from list method if available", () => {
       const appRaw = {
         resources: {


### PR DESCRIPTION
minor fix for creating a `searchOrCreate` only if both are visible. 

Also some unrelated improvements in that file while i was in there. 