### PR TITLE
Fix bug: Can't use unencrypted http:// protocol when SSL checks are disabled

### DIFF
--- a/src/http-middlewares/before/disable-ssl-cert-check.js
+++ b/src/http-middlewares/before/disable-ssl-cert-check.js
@@ -5,7 +5,7 @@ const https = require('https');
 const disableSSLCertCheck = req => {
   if (req.agent) {
     req.agent.options.rejectUnauthorized = false;
-  } else {
+  } else if (req.url.startsWith('https://')) {
     req.agent = new https.Agent({ rejectUnauthorized: false });
   }
   return req;

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -364,6 +364,15 @@ describe('request client', () => {
     });
   });
 
+  it('should allow unencrypted requests when SSL checks are disabled', () => {
+    const newInput = _.cloneDeep(input);
+    newInput._zapier.event.verifySSL = false;
+    const request = createAppRequestClient(newInput);
+    return request('http://zapier-httpbin.herokuapp.com/get').then(response => {
+      response.status.should.eql(200);
+    });
+  });
+
   it('should not omit empty params by default', () => {
     const request = createAppRequestClient(input);
     return request({


### PR DESCRIPTION
If a user disables the SSL checks in their settings:

![](https://zappy.zapier.com/43008014-650F-47D3-8144-73E859D608F9.png)

then the user can only send `https://` requests. Any unencrypted `http://` requests will cause an error saying:

```
Protocol "http:" not supported. Expected "https:"
```

The root cause is that we check if a user disables their SSL checks [here](https://github.com/zapier/zapier-platform-core/blob/42ad3a1716b6187fd70be62f1c5f4eaa40314318/src/http-middlewares/before/disable-ssl-cert-check.js), where we use `https.Agent` for all requests. Instead, we should use `https.Agent` only if it's an `https://` requests.

Fixes [PDE-625](https://zapierorg.atlassian.net/browse/PDE-625).