### PR TITLE
Resolving potential security vulnerability in lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2810,9 +2810,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5054,6 +5054,13 @@
       "requires": {
         "jsonschema": "1.1.1",
         "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "content-disposition": "0.5.2",
     "dotenv": "5.0.1",
     "form-data": "2.3.2",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "node-fetch": "1.7.1",
     "oauth-sign": "0.9.0",
     "semver": "5.6.0",


### PR DESCRIPTION
Fixing the `We found a potential security vulnerability in one of your dependencies` issue by bumping `lodash` to `4.17.11`

![image](https://user-images.githubusercontent.com/1595448/52524726-55dbbe80-2c6e-11e9-9400-01b34687914f.png)
