### PR TITLE
[PDE-646] Prune unmatched tokens from request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .DS_Store
 build-boilerplate
 *.tgz
+.vscode

--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,7 @@ export interface Bundle<InputData = { [x: string]: any }> {
     headers: { [x: string]: string };
     content: { [x: string]: string };
   }>;
+  subscribeData?: { id: string };
   targetUrl?: string;
 }
 
@@ -67,20 +68,24 @@ declare class RefreshAuthError extends Error {}
 
 // copied http stuff from external typings
 export interface HttpRequestOptions {
-  url?: string;
-  method?: HttpMethod;
+  agent?: Agent;
   body?: string | Buffer | ReadableStream | object;
+  compress?: boolean;
+  follow?: number;
+  form?: object;
   headers?: { [name: string]: string };
   json?: object | any[];
+  method?: HttpMethod;
   params?: object;
-  form?: object;
   raw?: boolean;
   redirect?: 'manual' | 'error' | 'follow';
-  follow?: number;
-  compress?: boolean;
-  agent?: Agent;
-  timeout?: number;
+  removeMissingValuesFrom: {
+    params: boolean,
+    body: boolean,
+  };
   size?: number;
+  timeout?: number;
+  url?: string;
 }
 
 interface BaseHttpResponse {

--- a/src/http-middlewares/before/add-query-params.js
+++ b/src/http-middlewares/before/add-query-params.js
@@ -2,27 +2,32 @@
 
 const querystring = require('querystring');
 
+const isCurlies = /{{.*?}}/g;
+const shouldPruneQueryParam = value =>
+  value === '' ||
+  value === null ||
+  value === undefined ||
+  isCurlies.test(value);
+
 // Mutates the object (it'll be deleted later anyway)
-const removeEmptyParams = params =>
-  Object.keys(params).map(param => {
-    if (
-      params[param] === '' ||
-      params[param] === null ||
-      typeof params[param] === 'undefined'
-    ) {
+const pruneMissingQueryParams = params =>
+  Object.keys(params).forEach(param => {
+    if (shouldPruneQueryParam(params[param])) {
       delete params[param];
     }
   });
+
+const hasQueryParams = ({ params = {} }) => Object.keys(params).length;
 
 // Take params off of req.params and append to url - "?a=1&b=2"".
 // This middleware should run *after* custom middlewares, because
 // custom middlewares might add params.
 const addQueryParams = req => {
-  if (Object.keys(req.params || {}).length) {
-    const splitter = req.url.indexOf('?') === -1 ? '?' : '&';
+  if (hasQueryParams(req)) {
+    const splitter = req.url.includes('?') ? '&' : '?';
 
-    if (req.omitEmptyParams) {
-      removeEmptyParams(req.params);
+    if (req.removeMissingValuesFrom.params) {
+      pruneMissingQueryParams(req.params);
     }
 
     const stringifiedParams = querystring.stringify(req.params);
@@ -31,6 +36,7 @@ const addQueryParams = req => {
       req.url += `${splitter}${stringifiedParams}`;
     }
   }
+
   delete req.params;
   return req;
 };

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -101,8 +101,12 @@ const prepareRequest = function(req) {
 
   req = _.defaults(req, {
     merge: true,
+    // TODO: client will eventually send `removeMissingValuesFrom` rather than `omitEmptyParams`
+    removeMissingValuesFrom: {
+      params: !!req.omitEmptyParams,
+      body: false
+    },
     replace: true, // always replace curlies
-    prune: false, // TODO: do we prune empty {{missing}} vars?,
     _addContext: () => {}
   });
 

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -30,27 +30,25 @@ const recurseCleanFuncs = (obj, path) => {
 };
 
 // Recurse a nested object replace all instances of keys->vals in the bank.
-const recurseReplaceBank = (obj, bank) => {
-  bank = bank || {};
+const recurseReplaceBank = (obj, bank = {}) => {
   const replacer = out => {
     if (typeof out !== 'string') {
       return out;
     }
     Object.keys(bank).forEach(key => {
+      // Escape characters (ex. {{foo}} => \\{\\{foo\\}\\} )
       const s = String(key).replace(/[-[\]/{}()\\*+?.^$|]/g, '\\$&');
       const re = new RegExp(s, 'g');
       out = out.replace(re, bank[key]);
     });
+
     return out;
   };
   return recurseReplace(obj, replacer);
 };
 
 // Takes a raw app and bundle and composes a bank of {{key}}->val
-const createBundleBank = (appRaw, event) => {
-  appRaw = appRaw || {};
-  event = event || {};
-
+const createBundleBank = (appRaw, event = {}) => {
   const bundle = event.bundle || {};
   const bank = {
     bundle: _.merge(

--- a/src/tools/request-client.js
+++ b/src/tools/request-client.js
@@ -13,7 +13,7 @@ const request = options => {
     'body',
     'merge', // internal
     'replace', // internal
-    'prune', // ready for the future
+    'removeMissingValuesFrom', // internal
     'redirect',
     'follow',
     'compress',

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -373,102 +373,122 @@ describe('request client', () => {
     });
   });
 
-  it('should not omit empty params by default', () => {
-    const request = createAppRequestClient(input);
-    return request({
-      url: 'http://zapier-httpbin.herokuapp.com/get',
-      params: {
-        something: '',
-        cool: 'true'
-      }
-    }).then(responseBefore => {
-      const response = JSON.parse(JSON.stringify(responseBefore));
+  describe('adds query params', () => {
+    it('should not omit empty params by default', () => {
+      const request = createAppRequestClient(input);
+      return request({
+        url: 'http://zapier-httpbin.herokuapp.com/get',
+        params: {
+          something: '',
+          really: '{{bundle.inputData.really}}',
+          cool: 'true'
+        }
+      }).then(responseBefore => {
+        const response = JSON.parse(JSON.stringify(responseBefore));
 
-      response.json.args.something.should.eql('');
-      response.json.args.cool.should.eql('true');
-      response.status.should.eql(200);
+        response.json.args.something.should.eql('');
+        response.json.args.really.should.eql('{{bundle.inputData.really}}');
+        response.json.args.cool.should.eql('true');
+        response.status.should.eql(200);
 
-      const body = JSON.parse(response.content);
-      body.url.should.eql(
-        'http://zapier-httpbin.herokuapp.com/get?something=&cool=true'
-      );
+        const body = JSON.parse(response.content);
+        body.url.should.eql(
+          'http://zapier-httpbin.herokuapp.com/get?something=&really={{bundle.inputData.really}}&cool=true'
+        );
+      });
     });
-  });
 
-  it('should not omit empty params when set as false', () => {
-    const request = createAppRequestClient(input);
-    return request({
-      url: 'http://zapier-httpbin.herokuapp.com/get',
-      params: {
-        something: '',
-        cool: 'true'
-      },
-      omitEmptyParams: false
-    }).then(responseBefore => {
-      const response = JSON.parse(JSON.stringify(responseBefore));
+    it('should not omit empty params when set as false', () => {
+      const request = createAppRequestClient(input);
+      return request({
+        url: 'http://zapier-httpbin.herokuapp.com/get',
+        params: {
+          something: '',
+          really: '{{bundle.inputData.really}}',
+          cool: 'true'
+        },
+        omitEmptyParams: false
+      }).then(responseBefore => {
+        const response = JSON.parse(JSON.stringify(responseBefore));
 
-      response.json.args.something.should.eql('');
-      response.json.args.cool.should.eql('true');
-      response.status.should.eql(200);
+        response.json.args.something.should.eql('');
+        response.json.args.really.should.eql('{{bundle.inputData.really}}');
+        response.json.args.cool.should.eql('true');
+        response.status.should.eql(200);
 
-      const body = JSON.parse(response.content);
-      body.url.should.eql(
-        'http://zapier-httpbin.herokuapp.com/get?something=&cool=true'
-      );
+        const body = JSON.parse(response.content);
+        body.url.should.eql(
+          'http://zapier-httpbin.herokuapp.com/get?something=&really={{bundle.inputData.really}}&cool=true'
+        );
+      });
     });
-  });
 
-  it('should omit empty params when set as true', () => {
-    const request = createAppRequestClient(input);
-    return request({
-      url: 'http://zapier-httpbin.herokuapp.com/get',
-      params: {
-        something: '',
-        cool: 'false',
-        foo: null,
-        bar: undefined,
-        zzz: '[]',
-        yyy: '{}',
-        qqq: ' '
-      },
-      omitEmptyParams: true
-    }).then(responseBefore => {
-      const response = JSON.parse(JSON.stringify(responseBefore));
-
-      should(response.json.args.something).eql(undefined);
-      should(response.json.args.foo).eql(undefined);
-      should(response.json.args.bar).eql(undefined);
-      response.json.args.cool.should.eql('false');
-      response.json.args.zzz.should.eql('[]');
-      response.json.args.yyy.should.eql('{}');
-      response.json.args.qqq.should.eql(' ');
-      response.status.should.eql(200);
-
-      const body = JSON.parse(response.content);
-      body.url.should.eql(
-        'http://zapier-httpbin.herokuapp.com/get?cool=false&zzz=[]&yyy={}&qqq= '
+    it('should omit empty params when set as true', () => {
+      const event = {
+        bundle: {
+          inputData: {
+            name: 'zapier'
+          }
+        }
+      };
+      const request = createAppRequestClient(
+        createInput({}, event, testLogger)
       );
+
+      return request({
+        url: 'http://zapier-httpbin.herokuapp.com/get',
+        params: {
+          something: '',
+          really: '{{bundle.inputData.really}}',
+          cool: 'false',
+          name: '{{bundle.inputData.name}}',
+          foo: null,
+          bar: undefined,
+          zzz: '[]',
+          yyy: '{}',
+          qqq: ' '
+        },
+        omitEmptyParams: true
+      }).then(responseBefore => {
+        const response = JSON.parse(JSON.stringify(responseBefore));
+
+        should(response.json.args.something).eql(undefined);
+        should(response.json.args.foo).eql(undefined);
+        should(response.json.args.bar).eql(undefined);
+        should(response.json.args.empty).eql(undefined);
+        response.json.args.cool.should.eql('false');
+        response.json.args.zzz.should.eql('[]');
+        response.json.args.yyy.should.eql('{}');
+        response.json.args.qqq.should.eql(' ');
+        response.json.args.name.should.eql('zapier');
+        response.status.should.eql(200);
+
+        const body = JSON.parse(response.content);
+        body.url.should.eql(
+          'http://zapier-httpbin.herokuapp.com/get?cool=false&name=zapier&zzz=[]&yyy={}&qqq= '
+        );
+      });
     });
-  });
 
-  it('should not include ? if there are no params after cleaning', () => {
-    const request = createAppRequestClient(input);
-    return request({
-      url: 'http://zapier-httpbin.herokuapp.com/get',
-      params: {
-        something: '',
-        cool: ''
-      },
-      omitEmptyParams: true
-    }).then(responseBefore => {
-      const response = JSON.parse(JSON.stringify(responseBefore));
+    it('should not include ? if there are no params after cleaning', () => {
+      const request = createAppRequestClient(input);
+      return request({
+        url: 'http://zapier-httpbin.herokuapp.com/get',
+        params: {
+          something: '',
+          cool: ''
+        },
+        omitEmptyParams: true
+      }).then(responseBefore => {
+        const response = JSON.parse(JSON.stringify(responseBefore));
 
-      should(response.json.args.something).eql(undefined);
-      should(response.json.args.cool).eql(undefined);
-      response.status.should.eql(200);
+        should(response.json.args.something).eql(undefined);
+        should(response.json.args.cool).eql(undefined);
+        response.status.should.eql(200);
 
-      const body = JSON.parse(response.content);
-      body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        const body = JSON.parse(response.content);
+        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
We had added `omitEmptyParams` to core a while back. The problem is that it only looks to see if the param value we send in the request is empty—not if we have a bundle token that has an empty input/replace value:

```js
const req = {
  url: 'https://api.foo.com/things/{{bundle.inputData.thingId}}',
  params: {
    someParam: 'zapier',
    getsIgnored: undefined,
    good: '{{bundle.inputData.good}}'
    bad: '{{bundle.inputData.bad}}'
  }
  input: {
    _zapier: { 
      bundle: { inputData: { good: 'hooray' } }
    }
  }
}
```

In this scenario, we'd get a url that resolves to `'https://api.foo.com/things/%7B%7Bbundle.inputData.thingId%7D%7D?someParam=zapier&good=hooray&bad=%7B%7Bbundle.inputData.bad%7D%7D'` when `omitEmptyParams: true`.

The expected url should be: `'https://api.foo.com/things/?someParam=zapier&good=hooray'`

Another consideration is it looks like we [left](https://github.com/zapier/zapier-platform-core/blob/06d97e3fca867f9007a3d22a171e0b72f0856ec5/src/http-middlewares/before/prepare-request.js#L105) the door [open](https://github.com/zapier/zapier-platform-core/blob/7bed19da1e550b76eda250afe6a8fc999478309e/src/tools/request-client.js#L16) for a `prune` field that would be sent with the request like `replace` or `merge`. Would we want to use this field? I'm not sure where we would set it in the request flow.

Possibly add it in [`requestMerge`](https://github.com/zapier/zapier-platform-core/blob/06d97e3fca867f9007a3d22a171e0b72f0856ec5/src/http-middlewares/before/prepare-request.js#L114) or right after (before we make replacements)?

## Jira Ticket
https://zapierorg.atlassian.net/browse/PDE-646