### PR TITLE
[PDE-723] Resolve subscription related bundle fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "version": "node bin/bump-dependencies.js && npm install && git add package.json package-lock.json",
     "postversion": "git push && git push --tags",
     "test": "mocha -t 10000 --recursive test",
+    "test:w": "mocha -t 10000 --recursive test --watch",
     "posttest": "npm run lint",
     "plain-test": "mocha -t 5000 --recursive test",
     "integration-test": "mocha -t 10000 integration-test",

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -1,10 +1,18 @@
 'use strict';
 
 const _ = require('lodash');
+const { defaults, pick, pipe } = require('lodash/fp');
 
 const isPlainObj = require('./data').isPlainObj;
 const recurseReplace = require('./data').recurseReplace;
 const flattenPaths = require('./data').flattenPaths;
+
+const DEFAULT_BUNDLE = {
+  authData: {},
+  inputData: {},
+  targetUrl: '',
+  subscribeData: {}
+};
 
 const recurseCleanFuncs = (obj, path) => {
   // mainly turn functions into $func${arity}${arguments}$
@@ -47,15 +55,15 @@ const recurseReplaceBank = (obj, bank = {}) => {
   return recurseReplace(obj, replacer);
 };
 
+const finalizeBundle = pipe(
+  pick(Object.keys(DEFAULT_BUNDLE)),
+  defaults(DEFAULT_BUNDLE)
+);
+
 // Takes a raw app and bundle and composes a bank of {{key}}->val
 const createBundleBank = (appRaw, event = {}) => {
-  const bundle = event.bundle || {};
   const bank = {
-    bundle: _.merge(
-      {},
-      { authData: bundle.authData || {} },
-      { inputData: bundle.inputData || {} }
-    ),
+    bundle: finalizeBundle(event.bundle),
     process: {
       env: _.extend({}, process.env || {})
     }

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -491,4 +491,47 @@ describe('request client', () => {
       });
     });
   });
+
+  describe('shorthand hook subscriptions', () => {
+    it('should resolve bundle tokens in performSubscribe', () => {
+      const targetUrl = 'https://zapier.com/hooks';
+      const event = {
+        bundle: { targetUrl }
+      };
+      const subscribeInput = createInput({}, event, testLogger);
+      const request = createAppRequestClient(subscribeInput);
+      return request({
+        url: 'http://zapier-httpbin.herokuapp.com/post',
+        method: 'POST',
+        body: {
+          hookUrl: '{{bundle.targetUrl}}'
+        }
+      }).then(response => {
+        const { hookUrl } = JSON.parse(response.json.data);
+
+        hookUrl.should.eql(targetUrl);
+      });
+    });
+
+    it('should resolve bundle tokens in performUnubscribe', () => {
+      const subscribeData = { id: 123 };
+      const event = {
+        bundle: { subscribeData }
+      };
+      const subscribeInput = createInput({}, event, testLogger);
+      const request = createAppRequestClient(subscribeInput);
+      return request({
+        url: 'http://zapier-httpbin.herokuapp.com/delete',
+        method: 'DELETE',
+        params: {
+          id: '{{bundle.subscribeData.id}}'
+        }
+      }).then(response => {
+        const { url } = JSON.parse(response.content);
+
+        response.json.args.id.should.eql('123');
+        url.should.eql('http://zapier-httpbin.herokuapp.com/delete?id=123');
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description
In Godzilla, devs have tried setting up hooks using form mode. The problem is that they need to use bundle fields that are not getting resolved via bundleBank in `/cleaner`. 

Now, we'll add `targetUrl` and `subscribeData` to the available bundle fields when resolving tokens from the request.

## Jira
https://zapierorg.atlassian.net/browse/PDE-723