### PR TITLE
[PDE-683] (BREAKING) Resolve curlies to their original data type

### DIFF
--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -14,6 +14,18 @@ const isPlainObj = o => {
 
 const comparison = (obj, needle) => obj === needle;
 
+const getObjectType = obj => {
+  if (_.isPlainObject(obj)) {
+    return 'Object';
+  }
+
+  if (Array.isArray(obj)) {
+    return 'Array';
+  }
+
+  return _.capitalize(typeof obj);
+};
+
 // Returns a path for the deeply nested haystack where
 // you could find the needle. If the needle is a plain
 // object we try _.isEqual (which could be slow!).
@@ -130,8 +142,7 @@ const recurseExtract = (obj, matcher) => {
 const _IGNORE = {};
 
 // Flatten a nested object.
-const flattenPaths = (data, sep) => {
-  sep = sep || '.';
+const flattenPaths = (data, sep = '.') => {
   const out = {};
   const recurse = (obj, prop) => {
     prop = prop || '';
@@ -179,6 +190,7 @@ module.exports = {
   findMapDeep,
   flattenPaths,
   genId,
+  getObjectType,
   isPlainObj,
   jsonCopy,
   memoizedFindMapDeep,


### PR DESCRIPTION
## Description
CLI integrations always use bundle values directly from the bundle we inject to their request functions:

```js
const perform = (z, bundle) => {
  const options = {
    url: 'http://api.example.com/post', 
	method: 'POST',
    body: {
      // We directly access the variable -- names: ['Ron', 'Veronica', 'Brick']
      names: bundle.inputData.names,
    }
  }

  z.request(options);
}
```

But, if we are using curly tokens to be replaced with an actual value, `core` interpolates value in a string. One example is in a perform shorthand RequestSchema.

```js
const perform = {
  url: 'http://api.example.com/post',
  method: 'POST',
  body: {
    // String.prototype.replace will coerce the data type to a string
    // Using the case above -- names: 'Ron,Veronica,Brick' 
    names: '{{bundle.inputData.names}}',
  }
```

This fix keeps the data types of values replaced via curlies. The one exception is when we have an interpolated value as part of a string (ex. `'Bearer {{bundle.authData.access_token}}'`). In this case we:
1. Add to the string as we did before
1. Throw an error if the type is a plain object or array

The tests do a better job of illustrating what we're doing now.

## Jira
https://zapierorg.atlassian.net/browse/PDE-683