### PR TITLE
[PDE-765] preserve objects passed to inputData in the bundle bank

### DIFF
--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -122,8 +122,7 @@ const prepareRequest = function(req) {
   if (req.replace) {
     const bank = cleaner.createBundleBank(
       input._zapier.app,
-      input._zapier.event,
-      { preserve: { 'bundle.inputData': true } }
+      input._zapier.event
     );
     req = cleaner.recurseReplaceBank(req, bank);
   }

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -122,7 +122,8 @@ const prepareRequest = function(req) {
   if (req.replace) {
     const bank = cleaner.createBundleBank(
       input._zapier.app,
-      input._zapier.event
+      input._zapier.event,
+      { preserve: { 'bundle.inputData': true } }
     );
     req = cleaner.recurseReplaceBank(req, bank);
   }

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -88,7 +88,7 @@ const finalizeBundle = pipe(
 );
 
 // Takes a raw app and bundle and composes a bank of {{key}}->val
-const createBundleBank = (appRaw, event = {}, flattenOptions) => {
+const createBundleBank = (appRaw, event = {}) => {
   const bank = {
     bundle: finalizeBundle(event.bundle),
     process: {
@@ -96,7 +96,8 @@ const createBundleBank = (appRaw, event = {}, flattenOptions) => {
     }
   };
 
-  const flattenedBank = flattenPaths(bank, flattenOptions);
+  const options = { preserve: { 'bundle.inputData': true } };
+  const flattenedBank = flattenPaths(bank, options);
   return Object.keys(flattenedBank).reduce((coll, key) => {
     coll[`{{${key}}}`] = flattenedBank[key];
     return coll;

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -88,7 +88,7 @@ const finalizeBundle = pipe(
 );
 
 // Takes a raw app and bundle and composes a bank of {{key}}->val
-const createBundleBank = (appRaw, event = {}) => {
+const createBundleBank = (appRaw, event = {}, flattenOptions) => {
   const bank = {
     bundle: finalizeBundle(event.bundle),
     process: {
@@ -96,7 +96,7 @@ const createBundleBank = (appRaw, event = {}) => {
     }
   };
 
-  const flattenedBank = flattenPaths(bank);
+  const flattenedBank = flattenPaths(bank, flattenOptions);
   return Object.keys(flattenedBank).reduce((coll, key) => {
     coll[`{{${key}}}`] = flattenedBank[key];
     return coll;

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -142,14 +142,17 @@ const recurseExtract = (obj, matcher) => {
 const _IGNORE = {};
 
 // Flatten a nested object.
-const flattenPaths = (data, sep = '.') => {
+const flattenPaths = (data, { preserve = {} } = {}) => {
   const out = {};
-  const recurse = (obj, prop) => {
-    prop = prop || '';
-    if (isPlainObj(obj)) {
-      Object.keys(obj).map(key => {
-        const value = obj[key];
-        const newProp = prop ? prop + sep + key : key;
+  const recurse = (obj, prop = '') => {
+    if (_.isPlainObject(obj)) {
+      Object.entries(obj).forEach(([key, value]) => {
+        const newProp = prop ? `${prop}.${key}` : key;
+
+        if (preserve[prop]) {
+          out[newProp] = value;
+        }
+
         const subValue = recurse(value, newProp);
         if (subValue !== _IGNORE) {
           out[newProp] = subValue;

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -183,6 +183,40 @@ describe('Tools', () => {
         i: undefined
       });
     });
+
+    it('should flatten things but preserve values from provided keys', () => {
+      const output = dataTools.flattenPaths(
+        {
+          a: {
+            b: 1,
+            c: 2,
+            d: {
+              e: 3,
+              z: {
+                y: 'because'
+              }
+            },
+            f: null
+          },
+          g: [4],
+          h: 5,
+          i: undefined
+        },
+        { preserve: { 'a.d': true } }
+      );
+
+      output.should.eql({
+        'a.b': 1,
+        'a.c': 2,
+        'a.d.e': 3,
+        'a.d.z': { y: 'because' },
+        'a.d.z.y': 'because',
+        'a.f': null,
+        g: [4],
+        h: 5,
+        i: undefined
+      });
+    });
   });
 
   describe('recurseExtract', () => {


### PR DESCRIPTION
## Description
When we pass values to `inputData` that are line items are dictionaries, they get flattened out. This prevents us from using these two input types in curlies (ex. `{{bundle.inputData.someDict}}`)—the flattened object skips over the top level `someDict` and only exposes its children. 

This fix keeps the behavior we have today and adds the preserved top level object as well.

## Jira
https://zapierorg.atlassian.net/browse/PDE-765