### PR TITLE
Allow tests to pass with httpbin.org while we figure httpbin

### DIFF
--- a/integration-test/integration-test.js
+++ b/integration-test/integration-test.js
@@ -244,7 +244,7 @@ const doTest = runner => {
             noun: 'Foo',
             operation: {
               perform: {
-                url: 'https://zapier-httpbin.herokuapp.com/get',
+                url: 'https://httpbin.org/get',
                 params: {
                   id: 54321
                 }
@@ -307,7 +307,7 @@ const doTest = runner => {
             operation: {
               perform: {
                 method: 'POST',
-                url: 'https://zapier-httpbin.herokuapp.com/post',
+                url: 'https://httpbin.org/post',
                 params: {
                   id: 54321
                 }
@@ -497,7 +497,7 @@ const doTest = runner => {
             operation: {
               perform: {
                 method: 'POST',
-                url: 'https://zapier-httpbin.herokuapp.com/post'
+                url: 'https://httpbin.org/post'
               }
             }
           }

--- a/test/create-app.js
+++ b/test/create-app.js
@@ -106,7 +106,7 @@ describe('create-app', () => {
 
     app(input)
       .then(output => {
-        // zapier-httpbin.herokuapp.com/get puts request headers in the response body (good for testing):
+        // httpbin.org/get puts request headers in the response body (good for testing):
         should.exist(output.results.headers);
 
         // verify that custom http before middleware was applied
@@ -131,10 +131,10 @@ describe('create-app', () => {
       })
       .catch(err => {
         should(err.message).startWith(
-          'Got 403 calling GET http://zapier-httpbin.herokuapp.com/status/403, expected 2xx.\nWhat happened:\n  Starting GET request to http://zapier-httpbin.herokuapp.com/status/403\n  Received 403 code from http://zapier-httpbin.herokuapp.com/status/403 after '
+          'Got 403 calling GET https://httpbin.org/status/403, expected 2xx.\nWhat happened:\n  Starting GET request to https://httpbin.org/status/403\n  Received 403 code from https://httpbin.org/status/403 after '
         );
         should(err.message).endWith(
-          'ms\n  Received content ""\n  Got 403 calling GET http://zapier-httpbin.herokuapp.com/status/403, expected 2xx.'
+          'ms\n  Received content ""\n  Got 403 calling GET https://httpbin.org/status/403, expected 2xx.'
         );
         done();
       })
@@ -150,10 +150,10 @@ describe('create-app', () => {
       })
       .catch(err => {
         should(err.message).startWith(
-          'Got 403 calling GET http://zapier-httpbin.herokuapp.com/status/403, expected 2xx.\nWhat happened:\n  Starting GET request to http://zapier-httpbin.herokuapp.com/status/403\n  Received 403 code from http://zapier-httpbin.herokuapp.com/status/403 after '
+          'Got 403 calling GET https://httpbin.org/status/403, expected 2xx.\nWhat happened:\n  Starting GET request to https://httpbin.org/status/403\n  Received 403 code from https://httpbin.org/status/403 after '
         );
         should(err.message).endWith(
-          'ms\n  Received content ""\n  Got 403 calling GET http://zapier-httpbin.herokuapp.com/status/403, expected 2xx.'
+          'ms\n  Received content ""\n  Got 403 calling GET https://httpbin.org/status/403, expected 2xx.'
         );
         done();
       })
@@ -267,9 +267,7 @@ describe('create-app', () => {
     const input = createTestInput('triggers.contactList.operation.perform');
     app(input)
       .then(output => {
-        output.results.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get'
-        );
+        output.results.url.should.eql('https://httpbin.org/get');
         output.results.headers['X-Hashy'].should.eql(
           '1a3ba5251cb33ee7ade01af6a7b960b8'
         );
@@ -322,16 +320,14 @@ describe('create-app', () => {
       command: 'request',
       bundle: {
         request: {
-          url: 'http://zapier-httpbin.herokuapp.com/get'
+          url: 'https://httpbin.org/get'
         }
       }
     });
     app(input)
       .then(output => {
         const response = output.results;
-        JSON.parse(response.content).url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get'
-        );
+        JSON.parse(response.content).url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -355,7 +351,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'http://zapier-httpbin.herokuapp.com/status/401'
+            url: 'https://httpbin.org/status/401'
           }
         },
         method: 'resources.executeRequestAsShorthand.list.operation.perform'
@@ -388,7 +384,7 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'http://zapier-httpbin.herokuapp.com/status/401'
+              url: 'https://httpbin.org/status/401'
             }
           }
         },
@@ -420,7 +416,7 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'http://zapier-httpbin.herokuapp.com/status/401'
+              url: 'https://httpbin.org/status/401'
             }
           }
         },

--- a/test/create-request-client.js
+++ b/test/create-request-client.js
@@ -15,7 +15,7 @@ describe('request client', () => {
 
   it('should include a user-agent header', done => {
     const request = createAppRequestClient(input);
-    request({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    request({ url: 'https://httpbin.org/get' })
       .then(responseBefore => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -23,7 +23,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -32,7 +32,7 @@ describe('request client', () => {
   it('should allow overriding the user-agent header', done => {
     const request = createAppRequestClient(input);
     request({
-      url: 'http://zapier-httpbin.herokuapp.com/get',
+      url: 'https://httpbin.org/get',
       headers: {
         'User-Agent': 'Zapier!'
       }
@@ -45,7 +45,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -53,7 +53,7 @@ describe('request client', () => {
 
   it('should have json serializable response', done => {
     const request = createAppRequestClient(input);
-    request({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    request({ url: 'https://httpbin.org/get' })
       .then(responseBefore => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -61,7 +61,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -69,11 +69,11 @@ describe('request client', () => {
 
   it('should wrap a request entirely', done => {
     const request = createAppRequestClient(input);
-    request({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    request({ url: 'https://httpbin.org/get' })
       .then(response => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -84,7 +84,7 @@ describe('request client', () => {
     const request = createAppRequestClient(input);
     request({
       method: 'POST',
-      url: 'http://zapier-httpbin.herokuapp.com/post',
+      url: 'https://httpbin.org/post',
       body: Promise.resolve(payload)
     })
       .then(response => {
@@ -151,11 +151,11 @@ describe('request client', () => {
 
   it('should support single url param', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/get')
+    request('https://httpbin.org/get')
       .then(response => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -163,11 +163,11 @@ describe('request client', () => {
 
   it('should support url param with options', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/get', { headers: { A: 'B' } })
+    request('https://httpbin.org/get', { headers: { A: 'B' } })
       .then(response => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         body.headers.A.should.eql('B');
         done();
       })
@@ -176,7 +176,7 @@ describe('request client', () => {
 
   it('should support bytes', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/bytes/1024')
+    request('https://httpbin.org/bytes/1024')
       .then(response => {
         response.status.should.eql(200);
         // it tries to decode the bytes /shrug
@@ -188,7 +188,7 @@ describe('request client', () => {
 
   it('should support bytes raw', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/bytes/1024', { raw: true })
+    request('https://httpbin.org/bytes/1024', { raw: true })
       .then(response => {
         response.status.should.eql(200);
         should(response.buffer).be.type('function');
@@ -201,7 +201,7 @@ describe('request client', () => {
 
   it('should support streaming bytes', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/stream-bytes/1024')
+    request('https://httpbin.org/stream-bytes/1024')
       .then(response => {
         response.status.should.eql(200);
         // it tries to decode the bytes /shrug
@@ -213,7 +213,7 @@ describe('request client', () => {
 
   it('should support streaming bytes raw', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/stream-bytes/1024', {
+    request('https://httpbin.org/stream-bytes/1024', {
       raw: true
     })
       .then(response => {
@@ -228,7 +228,7 @@ describe('request client', () => {
 
   it('should support streaming bytes raw as buffer', done => {
     const request = createAppRequestClient(input);
-    request('http://zapier-httpbin.herokuapp.com/stream-bytes/1024', {
+    request('https://httpbin.org/stream-bytes/1024', {
       raw: true
     })
       .then(response => {
@@ -256,7 +256,7 @@ describe('request client', () => {
       testLogger
     );
     const request = createAppRequestClient(inputWithBeforeMiddleware);
-    request({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    request({ url: 'https://httpbin.org/get' })
       .then(responseBefore => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -264,7 +264,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -284,7 +284,7 @@ describe('request client', () => {
       testLogger
     );
     const request = createAppRequestClient(inputWithAfterMiddleware);
-    request({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    request({ url: 'https://httpbin.org/get' })
       .then(responseBefore => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -292,7 +292,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -301,7 +301,7 @@ describe('request client', () => {
   it('should parse form type request body', done => {
     const request = createAppRequestClient(input);
     request({
-      url: 'http://zapier-httpbin.herokuapp.com/post',
+      url: 'https://httpbin.org/post',
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded'
@@ -327,7 +327,7 @@ describe('request client', () => {
   it('should not parse form type request body when string', done => {
     const request = createAppRequestClient(input);
     request({
-      url: 'http://zapier-httpbin.herokuapp.com/post',
+      url: 'https://httpbin.org/post',
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded'
@@ -368,7 +368,7 @@ describe('request client', () => {
     const newInput = _.cloneDeep(input);
     newInput._zapier.event.verifySSL = false;
     const request = createAppRequestClient(newInput);
-    return request('http://zapier-httpbin.herokuapp.com/get').then(response => {
+    return request('https://httpbin.org/get').then(response => {
       response.status.should.eql(200);
     });
   });
@@ -377,7 +377,7 @@ describe('request client', () => {
     it('should not omit empty params by default', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/get',
+        url: 'https://httpbin.org/get',
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -393,7 +393,7 @@ describe('request client', () => {
 
         const body = JSON.parse(response.content);
         body.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get?something=&really={{bundle.inputData.really}}&cool=true'
+          'https://httpbin.org/get?something=&really={{bundle.inputData.really}}&cool=true'
         );
       });
     });
@@ -401,7 +401,7 @@ describe('request client', () => {
     it('should not omit empty params when set as false', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/get',
+        url: 'https://httpbin.org/get',
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -420,7 +420,7 @@ describe('request client', () => {
 
         const body = JSON.parse(response.content);
         body.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get?something=&really={{bundle.inputData.really}}&cool=true'
+          'https://httpbin.org/get?something=&really={{bundle.inputData.really}}&cool=true'
         );
       });
     });
@@ -438,7 +438,7 @@ describe('request client', () => {
       );
 
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/get',
+        url: 'https://httpbin.org/get',
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -469,7 +469,7 @@ describe('request client', () => {
 
         const body = JSON.parse(response.content);
         body.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get?cool=false&name=zapier&zzz=[]&yyy={}&qqq= '
+          'https://httpbin.org/get?cool=false&name=zapier&zzz=[]&yyy={}&qqq= '
         );
       });
     });
@@ -477,7 +477,7 @@ describe('request client', () => {
     it('should not include ? if there are no params after cleaning', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/get',
+        url: 'https://httpbin.org/get',
         params: {
           something: '',
           cool: ''
@@ -493,7 +493,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('http://zapier-httpbin.herokuapp.com/get');
+        body.url.should.eql('https://httpbin.org/get');
       });
     });
   });
@@ -507,7 +507,7 @@ describe('request client', () => {
       const subscribeInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(subscribeInput);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/post',
+        url: 'https://httpbin.org/post',
         method: 'POST',
         body: {
           hookUrl: '{{bundle.targetUrl}}'
@@ -527,7 +527,7 @@ describe('request client', () => {
       const subscribeInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(subscribeInput);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/delete',
+        url: 'https://httpbin.org/delete',
         method: 'DELETE',
         params: {
           id: '{{bundle.subscribeData.id}}'
@@ -536,7 +536,7 @@ describe('request client', () => {
         const { url } = JSON.parse(response.content);
 
         response.json.args.id.should.eql('123');
-        url.should.eql('http://zapier-httpbin.herokuapp.com/delete?id=123');
+        url.should.eql('https://httpbin.org/delete?id=123');
       });
     });
   });
@@ -556,7 +556,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/post',
+        url: 'https://httpbin.org/post',
         method: 'POST',
         body: {
           number: '{{bundle.inputData.number}}',
@@ -588,7 +588,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/post',
+        url: 'https://httpbin.org/post',
         method: 'POST',
         body: {
           message: 'We just got #{{bundle.inputData.resourceId}}'
@@ -615,7 +615,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/post',
+        url: 'https://httpbin.org/post',
         method: 'POST',
         body: {
           message: 'No arrays, thank you: {{bundle.inputData.badData}}'
@@ -639,7 +639,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'http://zapier-httpbin.herokuapp.com/post',
+        url: 'https://httpbin.org/post',
         method: 'POST',
         body: {
           streetAddress: '{{bundle.inputData.address.street}}',

--- a/test/http-middleware.js
+++ b/test/http-middleware.js
@@ -27,7 +27,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    wrappedRequest({ url: 'https://httpbin.org/get' })
       .then(response => {
         response.status.should.eql(200);
         JSON.parse(response.content).headers.Customheader.should.eql(
@@ -54,7 +54,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    wrappedRequest({ url: 'https://httpbin.org/get' })
       .then(response => {
         response.status.should.eql(200);
         JSON.parse(response.content).headers.Customheader.should.eql(
@@ -80,12 +80,10 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'http://zapier-httpbin.herokuapp.com/get' }).catch(
-      err => {
-        err.message.should.containEql('Middleware should return an object.');
-        done();
-      }
-    );
+    wrappedRequest({ url: 'https://httpbin.org/get' }).catch(err => {
+      err.message.should.containEql('Middleware should return an object.');
+      done();
+    });
   });
 
   it('should support async after middleware', done => {
@@ -103,7 +101,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    wrappedRequest({ url: 'https://httpbin.org/get' })
       .then(response => {
         response.status.should.eql(200);
         should.not.exist(response.results); // should not be 'enveloped'
@@ -128,7 +126,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    wrappedRequest({ url: 'https://httpbin.org/get' })
       .then(response => {
         response.status.should.eql(200);
         JSON.parse(response.content).customKey.should.eql('custom value');

--- a/test/logger.js
+++ b/test/logger.js
@@ -6,7 +6,7 @@ const querystring = require('querystring');
 
 describe('logger', () => {
   const options = {
-    endpoint: 'http://zapier-httpbin.herokuapp.com/post',
+    endpoint: 'https://httpbin.org/post',
     token: 'fake-token'
   };
 

--- a/test/request-client-internal.js
+++ b/test/request-client-internal.js
@@ -5,26 +5,22 @@ const request = require('../src/tools/request-client-internal');
 
 describe('http requests', () => {
   it('should make GET requests', done => {
-    request({ url: 'http://zapier-httpbin.herokuapp.com/get' })
+    request({ url: 'https://httpbin.org/get' })
       .then(response => {
         response.status.should.eql(200);
         should.exist(response.content);
-        response.content.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get'
-        );
+        response.content.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
   });
 
   it('should make GET with url sugar param', done => {
-    request('http://zapier-httpbin.herokuapp.com/get')
+    request('https://httpbin.org/get')
       .then(response => {
         response.status.should.eql(200);
         should.exist(response.content);
-        response.content.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get'
-        );
+        response.content.url.should.eql('https://httpbin.org/get');
         done();
       })
       .catch(done);
@@ -32,13 +28,11 @@ describe('http requests', () => {
 
   it('should make GET with url sugar param and options', done => {
     const options = { headers: { A: 'B' } };
-    request('http://zapier-httpbin.herokuapp.com/get', options)
+    request('https://httpbin.org/get', options)
       .then(response => {
         response.status.should.eql(200);
         should.exist(response.content);
-        response.content.url.should.eql(
-          'http://zapier-httpbin.herokuapp.com/get'
-        );
+        response.content.url.should.eql('https://httpbin.org/get');
         response.content.headers.A.should.eql('B');
         done();
       })
@@ -47,7 +41,7 @@ describe('http requests', () => {
 
   it('should make POST requests', done => {
     request({
-      url: 'http://zapier-httpbin.herokuapp.com/post',
+      url: 'https://httpbin.org/post',
       method: 'POST',
       body: 'test'
     })

--- a/test/tools/file-stasher.js
+++ b/test/tools/file-stasher.js
@@ -100,10 +100,9 @@ describe('file upload', () => {
     mocky.mockUpload();
 
     const request = createAppRequestClient(input);
-    const file = request(
-      'http://zapier-httpbin.herokuapp.com/stream-bytes/1024',
-      { raw: true }
-    );
+    const file = request('https://httpbin.org/stream-bytes/1024', {
+      raw: true
+    });
     stashFile(file)
       .then(url => {
         should(url).eql(
@@ -237,7 +236,7 @@ describe('file upload', () => {
 
     const request = createAppRequestClient(input);
     const file = request({
-      url: 'https://zapier-httpbin.herokuapp.com/response-headers',
+      url: 'https://httpbin.org/response-headers',
       params: {
         'Content-Disposition': 'inline; filename="an example.json"'
       },

--- a/test/userapp/index.js
+++ b/test/userapp/index.js
@@ -1,6 +1,6 @@
 // an example app!
 
-process.env.BASE_URL = 'http://zapier-httpbin.herokuapp.com';
+process.env.BASE_URL = 'https://httpbin.org';
 
 const _ = require('lodash');
 const helpers = require('./helpers');
@@ -146,11 +146,9 @@ const RequestSugar = {
     },
     operation: {
       perform: (z /* , bundle */) => {
-        return z
-          .request('http://zapier-httpbin.herokuapp.com/get')
-          .then(resp => {
-            return JSON.parse(resp.content);
-          });
+        return z.request('https://httpbin.org/get').then(resp => {
+          return JSON.parse(resp.content);
+        });
       }
     }
   }
@@ -214,7 +212,7 @@ const FailerHttp = {
     },
     operation: {
       perform: {
-        url: 'http://zapier-httpbin.herokuapp.com/status/403'
+        url: 'https://httpbin.org/status/403'
       }
     }
   }
@@ -440,7 +438,7 @@ const ExecuteRequestAsShorthand = {
       inputFields: [
         {
           key: 'url',
-          default: 'http://zapier-httpbin.herokuapp.com/status/403'
+          default: 'https://httpbin.org/status/403'
         }
       ]
     }


### PR DESCRIPTION
## Description

The httpbin instance we were using no longer exists on heroku. But, the httpbin instance we're now using company wide has a bug that wraps all string values in arrays.

For now, we'll use the public httpbin.org until we can iron out our internal httpbin.