### PR TITLE
fix individual types for removeMissingValuesFrom object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,8 +80,8 @@ export interface HttpRequestOptions {
   raw?: boolean;
   redirect?: 'manual' | 'error' | 'follow';
   removeMissingValuesFrom?: {
-    params: boolean,
-    body: boolean,
+    params?: boolean;
+    body?: boolean;
   };
   size?: number;
   timeout?: number;


### PR DESCRIPTION
I swear I'll get this. In addition to the object itself being optional, each property on it is optional. 