### PR TITLE
pass correct storekey

### DIFF
--- a/src/tools/create-app-tester.js
+++ b/src/tools/create-app-tester.js
@@ -46,17 +46,17 @@ const createAppTester = (appRaw, customStoreKey) => {
     bundle = bundle || {};
 
     const method = resolveMethodPath(appRaw, methodOrFunc);
-    customStoreKey = shouldPaginate(appRaw, method)
-    ? customStoreKey
-      ? `testKey-${customStoreKey}`
-      : `testKey-${method}-${randomSeed}`
-    : null;
+    const storeKey = shouldPaginate(appRaw, method)
+      ? customStoreKey
+        ? `testKey-${customStoreKey}`
+        : `testKey-${method}-${randomSeed}`
+      : null;
 
     const event = {
       command: 'execute',
       method,
       bundle,
-      customStoreKey,
+      storeKey
     };
 
     if (process.env.LOG_TO_STDOUT) {


### PR DESCRIPTION
the important piece here is that `event.storeKey` exists. I couldn't figure out how to get a good test for this (it's pretty embedded in there) but I might add a smoke test at some point. 