### PR TITLE
Add meta to the bundle bank for resolving curlies.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,12 +37,10 @@ export interface Bundle<InputData = { [x: string]: any }> {
   inputData: InputData;
   inputDataRaw: { [x: string]: string };
   meta: {
-    frontend: boolean;
-    prefill: boolean;
-    hydrate: boolean;
-    test_poll: boolean;
-    standard_poll: boolean;
-    first_poll: boolean;
+    isFillingDynamicDropdown: boolean;
+    isLoadingSample: boolean;
+    isPopulatingDedupe: boolean;
+    isTestingAuth: boolean;
     limit: number;
     page: number;
     zap?: { id: string };

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -13,8 +13,9 @@ const {
 const DEFAULT_BUNDLE = {
   authData: {},
   inputData: {},
-  targetUrl: '',
-  subscribeData: {}
+  meta: {},
+  subscribeData: {},
+  targetUrl: ''
 };
 
 const recurseCleanFuncs = (obj, path) => {


### PR DESCRIPTION
## Description
Meta was left out when adding the ability to resolve curlies. Here we add `meta` to the bundle defaults so it gets added to the bank. Also updated our typedef with the new meta fields.

It should be noted that we are still omitting `rawRequest`, `inputDataRaw`, and `cleanedRequest`, as I believe we decided these were only useful in scripting. Does that sound right @xavdid?