### PR TITLE
skip http patching

### DIFF
--- a/include/zapierwrapper.js
+++ b/include/zapierwrapper.js
@@ -4,7 +4,7 @@ const zapier = require('zapier-platform-core');
 const appPath = path.resolve(__dirname, 'index.js');
 let opts;
 try {
-  opts = require(appPath).appFlags;
+  opts = require(appPath).flags;
 } catch (error) {
   // nothing to see here
 }

--- a/include/zapierwrapper.js
+++ b/include/zapierwrapper.js
@@ -2,4 +2,10 @@
 const path = require('path');
 const zapier = require('zapier-platform-core');
 const appPath = path.resolve(__dirname, 'index.js');
-module.exports = {handler: zapier.createAppHandler(appPath)};
+let opts;
+try {
+  opts = require(appPath).appFlags;
+} catch (error) {
+  // nothing to see here
+}
+module.exports = { handler: zapier.createAppHandler(appPath, opts) };

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export const tools: { env: { inject: (filename?: string) => void } };
 // see: https://github.com/zapier/zapier-platform-cli/issues/339#issue-336888249
 export const createAppTester: (
   appRaw: object,
-  options?: { customStoreKey?: string; skipHttpPatch?: boolean }
+  options?: { customStoreKey?: string }
 ) => <T extends any, B extends Bundle>(
   func: (z: ZObject, bundle: B) => Promise<T>,
   bundle?: Partial<B> // partial so we don't have to make a full bundle in tests

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export const tools: { env: { inject: (filename?: string) => void } };
 // see: https://github.com/zapier/zapier-platform-cli/issues/339#issue-336888249
 export const createAppTester: (
   appRaw: object,
-  customStoreKey?: string
+  options?: { customStoreKey?: string; skipHttpPatch?: boolean }
 ) => <T extends any, B extends Bundle>(
   func: (z: ZObject, bundle: B) => Promise<T>,
   bundle?: Partial<B> // partial so we don't have to make a full bundle in tests

--- a/src/tools/create-app-tester.js
+++ b/src/tools/create-app-tester.js
@@ -36,8 +36,9 @@ const promisifyHandler = handler => {
 };
 
 // A shorthand compatible wrapper for testing.
-const createAppTester = (appRaw, { customStoreKey, skipHttpPatch } = {}) => {
-  const handler = createLambdaHandler(appRaw, { skipHttpPatch });
+const createAppTester = (appRaw, { customStoreKey } = {}) => {
+  const opts = appRaw.appFlags;
+  const handler = createLambdaHandler(appRaw, opts);
   const createHandlerPromise = promisifyHandler(handler);
 
   const randomSeed = genId();

--- a/src/tools/create-app-tester.js
+++ b/src/tools/create-app-tester.js
@@ -37,7 +37,7 @@ const promisifyHandler = handler => {
 
 // A shorthand compatible wrapper for testing.
 const createAppTester = (appRaw, { customStoreKey } = {}) => {
-  const opts = appRaw.appFlags;
+  const opts = appRaw.flags;
   const handler = createLambdaHandler(appRaw, opts);
   const createHandlerPromise = promisifyHandler(handler);
 

--- a/src/tools/create-app-tester.js
+++ b/src/tools/create-app-tester.js
@@ -36,8 +36,8 @@ const promisifyHandler = handler => {
 };
 
 // A shorthand compatible wrapper for testing.
-const createAppTester = (appRaw, customStoreKey) => {
-  const handler = createLambdaHandler(appRaw);
+const createAppTester = (appRaw, { customStoreKey, skipHttpPatch } = {}) => {
+  const handler = createLambdaHandler(appRaw, { skipHttpPatch });
   const createHandlerPromise = promisifyHandler(handler);
 
   const randomSeed = genId();

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -130,11 +130,13 @@ const loadApp = (event, rpc, appRawOrPath) => {
   });
 };
 
-const createLambdaHandler = appRawOrPath => {
+const createLambdaHandler = (appRawOrPath, { skipHttpPatch } = {}) => {
   const handler = (event, context, callback) => {
     // Adds logging for _all_ kinds of http(s) requests, no matter the library
-    const httpPatch = createHttpPatch(event);
-    httpPatch(require('http')); // 'https' uses 'http' under the hood
+    if (!skipHttpPatch) {
+      const httpPatch = createHttpPatch(event);
+      httpPatch(require('http')); // 'https' uses 'http' under the hood
+    }
 
     // Wait for all async events to complete before callback returns.
     // This is not strictly necessary since this is the default now when

--- a/test/tools/http-patch.js
+++ b/test/tools/http-patch.js
@@ -5,27 +5,24 @@ const should = require('should');
 const createAppTester = require('../../src/tools/create-app-tester');
 const appDefinition = require('../userapp');
 
-// this doesn't work for core modules like 'http' which don't use the cache
-const requireUncached = m => {
-  delete require.cache[require.resolve(m)];
-  return require(m);
-};
-
-describe('create-lambda-handler', () => {
+describe.skip('create-lambda-handler', () => {
   // this block is skipped because there's no way to un-modify 'http' once we've done it
   // I've verified that the bottom test works in isolation, but doesn't when it's part of the larger suite
-  describe.skip('http patch', () => {
+  describe('http patch', () => {
     it('should patch by default', async () => {
       const appTester = createAppTester(appDefinition);
       await appTester(appDefinition.resources.list.list.operation.perform);
-      const http = requireUncached('http');
+      const http = require('http'); // core modules are never cached
       should(http.patchedByZapier).eql(true);
     });
 
     it('should be ablet opt out of patch', async () => {
-      const appTester = createAppTester(appDefinition, { skipHttpPatch: true });
+      const appTester = createAppTester({
+        ...appDefinition,
+        appFlags: { skipHttpPatch: true }
+      });
       await appTester(appDefinition.resources.list.list.operation.perform);
-      const http = requireUncached('http');
+      const http = require('http'); // core modules are never cached
       should(http.patchedByZapier).eql(undefined);
     });
   });

--- a/test/tools/http-patch.js
+++ b/test/tools/http-patch.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const should = require('should');
+
+const createAppTester = require('../../src/tools/create-app-tester');
+const appDefinition = require('../userapp');
+
+// this doesn't work for core modules like 'http' which don't use the cache
+const requireUncached = m => {
+  delete require.cache[require.resolve(m)];
+  return require(m);
+};
+
+describe('create-lambda-handler', () => {
+  // this block is skipped because there's no way to un-modify 'http' once we've done it
+  // I've verified that the bottom test works in isolation, but doesn't when it's part of the larger suite
+  describe.skip('http patch', () => {
+    it('should patch by default', async () => {
+      const appTester = createAppTester(appDefinition);
+      await appTester(appDefinition.resources.list.list.operation.perform);
+      const http = requireUncached('http');
+      should(http.patchedByZapier).eql(true);
+    });
+
+    it('should be ablet opt out of patch', async () => {
+      const appTester = createAppTester(appDefinition, { skipHttpPatch: true });
+      await appTester(appDefinition.resources.list.list.operation.perform);
+      const http = requireUncached('http');
+      should(http.patchedByZapier).eql(undefined);
+    });
+  });
+});

--- a/test/tools/http-patch.js
+++ b/test/tools/http-patch.js
@@ -19,7 +19,7 @@ describe.skip('create-lambda-handler', () => {
     it('should be ablet opt out of patch', async () => {
       const appTester = createAppTester({
         ...appDefinition,
-        appFlags: { skipHttpPatch: true }
+        flags: { skipHttpPatch: true }
       });
       await appTester(appDefinition.resources.list.list.operation.perform);
       const http = require('http'); // core modules are never cached


### PR DESCRIPTION
@reganstarr ran into an issue where our changing of the core `http` module caused the AWS SDK to stop working as expected. this allows the lambda handler to be created without patching `http`. Currently this works for tests (where the handler is created directly) but not in the actual running of the app (which i'll need to think on a little more). Will probably have to add something to the schema. 

Note that i wasn't able to get the tests working. While normal requires go use a cache (such as `require('lodash')`, core modules (like `http`) don't. Additionally, all core requires share an instance and (as far as I can find) there's not a way around that. A quick example:

```js
function requireUncached(module){
    delete require.cache[require.resolve(module)]
    return require(module)
}

require.cache // => {}

const l = require('lodash')
const l2 = require('lodash')

Object.keys(require.cache) // => [ '/Users/david/projects/zapier/platform-core/node_modules/lodash/lodash.js' ]
l === l2 // => true
const l3 = requireUncached('lodash')
l === l3 // => false

// new session

const h = require('http')
require.cache // => {}
const h2 = require('http')
h === h2 // => true
const h3 = requireUncached('http')
h === h3 // => true
```

Since core modules don't use the cache, I can't find a way to get a "clean" copy. I think long-term it'd be nice to not modify the core module (that seems like a no-no) but being able to log all http requests is certainly nice. @stevelikesmusic do you have any ideas?