### PR TITLE
Censor auth headers

### DIFF
--- a/src/http-middlewares/after/log-response.js
+++ b/src/http-middlewares/after/log-response.js
@@ -1,31 +1,10 @@
 'use strict';
 
-const prepHeaders = headers => {
-  headers = headers || {};
-
-  if (headers && typeof headers.forEach === 'function') {
-    const _headers = {};
-    headers.forEach((value, name) => {
-      _headers[name] = value;
-    });
-    headers = _headers;
-  }
-
-  return Object.keys(headers).map(k => {
-    const v = headers[k];
-    return `${k}: ${v}`;
-  });
-};
-
 // Prepare a request/reponse to be logged to the backend.
 // Generally respects the "Zapier" request and resp object format.
 const prepareRequestLog = (req, resp) => {
   req = req || {};
   resp = resp || {};
-
-  const requestHeaders = prepHeaders(req.headers);
-
-  const respHeaders = prepHeaders(resp.headers);
 
   let body;
   if (!req.raw) {
@@ -43,11 +22,11 @@ const prepareRequestLog = (req, resp) => {
     request_type: 'devplatform-outbound',
     request_url: req.url,
     request_method: req.method || 'GET',
-    request_headers: requestHeaders.join('\n'),
+    request_headers: req.headers,
     request_data: req.body,
     request_via_client: true,
     response_status_code: resp.status,
-    response_headers: respHeaders.join('\n'),
+    response_headers: resp.headers,
     response_content: body
   };
 

--- a/src/http-middlewares/after/middleware-utils.js
+++ b/src/http-middlewares/after/middleware-utils.js
@@ -1,0 +1,27 @@
+// prepare headers object - plain object for serialization later
+const plainHeaders = headers => {
+  const _headers = {};
+  headers.forEach((value, name) => {
+    _headers[name] = value;
+  });
+  return _headers;
+};
+
+// Return the normal resp.headers, but with more goodies (toJSON support).
+const replaceHeaders = resp => {
+  const getHeader = name => resp.headers.get(name);
+
+  Object.defineProperty(resp.headers, 'toJSON', {
+    enumerable: false,
+    value: () => plainHeaders(resp.headers)
+  });
+
+  return {
+    headers: resp.headers,
+    getHeader
+  };
+};
+
+module.exports = {
+  replaceHeaders
+};

--- a/src/http-middlewares/after/prepare-response.js
+++ b/src/http-middlewares/after/prepare-response.js
@@ -2,30 +2,7 @@
 
 const _ = require('lodash');
 const throwForStatus = require('./throw-for-status');
-
-// prepare headers object - plain object for serialization later
-const plainHeaders = headers => {
-  const _headers = {};
-  headers.forEach((value, name) => {
-    _headers[name] = value;
-  });
-  return _headers;
-};
-
-// Return the normal resp.headers, but with more goodies (toJSON support).
-const replaceHeaders = resp => {
-  const getHeader = name => resp.headers.get(name);
-
-  Object.defineProperty(resp.headers, 'toJSON', {
-    enumerable: false,
-    value: () => plainHeaders(resp.headers)
-  });
-
-  return {
-    headers: resp.headers,
-    getHeader
-  };
-};
+const { replaceHeaders } = require('./middleware-utils');
 
 const prepareRawResponse = (resp, request) => {
   // TODO: if !2xx should we go ahead and get response.content for them?

--- a/src/tools/create-http-patch.js
+++ b/src/tools/create-http-patch.js
@@ -50,15 +50,6 @@ const createHttpPatch = event => {
 
       // Proxy the callback to get the response
       const newCallback = function(response) {
-        const requestHeaders = _.map(
-          Object.keys(options.headers || {}),
-          header => `${header}: ${options.headers[header]}`
-        );
-        const responseHeaders = _.map(
-          Object.keys(response.headers || {}),
-          header => `${header}: ${response.headers[header]}`
-        );
-
         const chunks = [];
 
         const sendToLogger = responseBody => {
@@ -68,11 +59,11 @@ const createHttpPatch = event => {
             request_type: 'devplatform-outbound',
             request_url: requestUrl,
             request_method: options.method || 'GET',
-            request_headers: requestHeaders.join('\n'),
+            request_headers: options.headers,
             request_data: options.body || '',
             request_via_client: false,
             response_status_code: response.statusCode,
-            response_headers: responseHeaders.join('\n'),
+            response_headers: response.headers,
             response_content: responseBody
           };
 

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -87,6 +87,7 @@ const makeSensitiveBank = (event, data) => {
         const censored = hashing.snipify(val);
         bank[val] = censored;
         bank[encodeURIComponent(val)] = censored;
+        bank[Buffer.from(val).toString('base64')] = censored;
       }
       return bank;
     },

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -11,6 +11,18 @@ const constants = require('../constants');
 
 const truncate = str => dataTools.simpleTruncate(str, 3500, ' [...]');
 
+const formatHeaders = (headers = {}) => {
+  if (_.isString(headers)) {
+    // we had a bug where headers coming in as strings weren't getting censored. If something calls this with stringified headers, we'll bow out. Pass the raw object instead.
+    return 'WARNING: possibly uncesored headers';
+  }
+  return Object.entries(headers)
+    .map(([header, value]) => {
+      return `${header}: ${value}`;
+    })
+    .join('\n');
+};
+
 // format HTTP request details into string suitable for printing to stdout
 const httpDetailsLogMessage = data => {
   if (data.log_type !== 'http') {
@@ -115,6 +127,9 @@ const sendLog = (options, event, message, data) => {
       safeData[key] = unsafeData[key];
     }
   });
+
+  safeData.request_headers = formatHeaders(safeData.request_headers);
+  safeData.response_headers = formatHeaders(safeData.response_headers);
 
   const body = {
     message: safeMessage,

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -14,7 +14,7 @@ const truncate = str => dataTools.simpleTruncate(str, 3500, ' [...]');
 const formatHeaders = (headers = {}) => {
   if (_.isString(headers)) {
     // we had a bug where headers coming in as strings weren't getting censored. If something calls this with stringified headers, we'll bow out. Pass the raw object instead.
-    return 'WARNING: possibly uncesored headers';
+    return 'ERR - refusing to log possibly uncesored headers';
   }
   return Object.entries(headers)
     .map(([header, value]) => {

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -8,19 +8,31 @@ const dataTools = require('./data');
 const hashing = require('./hashing');
 const ZapierPromise = require('./promise');
 const constants = require('../constants');
+const { unheader } = require('./http');
 
 const truncate = str => dataTools.simpleTruncate(str, 3500, ' [...]');
 
 const formatHeaders = (headers = {}) => {
+  if (_.isEmpty(headers)) {
+    return undefined;
+  }
   if (_.isString(headers)) {
     // we had a bug where headers coming in as strings weren't getting censored. If something calls this with stringified headers, we'll bow out. Pass the raw object instead.
-    return 'ERR - refusing to log possibly uncesored headers';
+    return 'ERR - refusing to log possibly uncensored headers';
   }
-  return Object.entries(headers)
+
+  return Object.entries(unheader(headers))
     .map(([header, value]) => {
       return `${header}: ${value}`;
     })
     .join('\n');
+};
+
+const maybeStringify = d => {
+  if (_.isPlainObject(d) || Array.isArray(d)) {
+    return JSON.stringify(d);
+  }
+  return d;
 };
 
 // format HTTP request details into string suitable for printing to stdout
@@ -49,15 +61,15 @@ const httpDetailsLogMessage = data => {
 ${trimmedData.request_method || 'GET'} ${
     trimmedData.request_url
   }${trimmedData.request_params || ''}
-${trimmedData.request_headers || ''}
+${formatHeaders(trimmedData.request_headers) || ''}
 
-${trimmedData.request_data || ''}
+${maybeStringify(trimmedData.request_data) || ''}
 
 ${trimmedData.response_status_code || 0}
 
-${trimmedData.response_headers || ''}
+${formatHeaders(trimmedData.response_headers) || ''}
 
-${trimmedData.response_content || ''}
+${maybeStringify(trimmedData.response_content) || ''}
 `.trim();
 };
 
@@ -110,6 +122,9 @@ const makeSensitiveBank = (event, data) => {
 const sendLog = (options, event, message, data) => {
   data = _.extend({}, data || {}, event.logExtra || {});
   data.log_type = data.log_type || 'console';
+
+  data.request_headers = unheader(data.request_headers);
+  data.response_headers = unheader(data.response_headers);
 
   const sensitiveBank = makeSensitiveBank(event, data);
   const safeMessage = truncate(

--- a/src/tools/data.js
+++ b/src/tools/data.js
@@ -169,6 +169,9 @@ const flattenPaths = (data, { preserve = {} } = {}) => {
 
 // A simpler, and memory-friendlier version of _.truncate()
 const simpleTruncate = (string, length, suffix) => {
+  if (string === undefined) {
+    return string;
+  }
   if (!string || !string.toString) {
     return '';
   }

--- a/src/tools/http.js
+++ b/src/tools/http.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const fetch = require('node-fetch');
 
 const FORM_TYPE = 'application/x-www-form-urlencoded';
 const JSON_TYPE = 'application/json';
@@ -93,10 +94,14 @@ const parseDictHeader = s => {
   return res;
 };
 
+const unheader = h =>
+  h instanceof fetch.Headers && _.isFunction(h.toJSON) ? h.toJSON() : h;
+
 module.exports = {
   FORM_TYPE,
   JSON_TYPE,
   JSON_TYPE_UTF8,
   getContentType,
-  parseDictHeader
+  parseDictHeader,
+  unheader
 };

--- a/test/logger.js
+++ b/test/logger.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('should');
+const should = require('should');
 const createlogger = require('../src/tools/create-logger');
 const querystring = require('querystring');
 
@@ -73,6 +73,28 @@ describe('logger', () => {
           key: ':censored:6:8f63f9ff57:'
         }
       });
+    });
+  });
+
+  it('should censor auth headers', () => {
+    const bundle = {
+      authData: {
+        key: 'verysecret'
+      },
+      headers: {
+        AuthorizationPlain: 'basic verysecret',
+        AuthorizationEncoded: 'basic dmVyeXNlY3JldA=='
+      }
+    };
+    const logger = createlogger({ bundle }, options);
+
+    const data = bundle.authData;
+
+    return logger(bundle.headers, data).then(response => {
+      response.status.should.eql(200);
+      const j = response.content.json;
+      should(j.message.AuthorizationPlain.includes('censored')).eql(true);
+      should(j.message.AuthorizationEncoded.includes('censored')).eql(true);
     });
   });
 

--- a/test/misc-tools.js
+++ b/test/misc-tools.js
@@ -58,7 +58,7 @@ describe('Tools', () => {
   it('should truncate many things!', () => {
     const tests = [
       { value: null, length: 5, suffix: undefined, expected: '' },
-      { value: undefined, length: 5, suffix: '...', expected: '' },
+      { value: undefined, length: 5, suffix: '...', expected: undefined },
       { value: false, length: 5, suffix: '...', expected: '' },
       { value: '', length: 5, suffix: undefined, expected: '' },
       { value: [], length: 5, suffix: '...', expected: '' },
@@ -92,9 +92,9 @@ describe('Tools', () => {
     ];
 
     tests.forEach(test => {
-      dataTools
-        .simpleTruncate(test.value, test.length, test.suffix)
-        .should.eql(test.expected);
+      should(
+        dataTools.simpleTruncate(test.value, test.length, test.suffix)
+      ).eql(test.expected);
     });
   });
 


### PR DESCRIPTION
fixes https://github.com/zapier/zapier/issues/25575.

@codebycaleb nailed the root cause - headers were coming into the logging method on strings, so our fancy recursing for sensitive looking keys didn't actually see the keys. This fixes it so we only only log the headers if we know they arrived as objects.

## Testing

1. `zapier init censortest --template=custom-auth`
2. replace the middleware in `index.js` with the following:

```js
const includeApiKey = (request, z, bundle) => {
  if (bundle.authData.apiKey) {
    const basicHash = Buffer.from(`:${bundle.authData.apiKey}`).toString('base64')
    request.headers.Authorization = `Basic ${basicHash}`
  }
  return request
}
```

3. `zapier push`
4. try to create an auth with any random string (`blahasdfhashdf`); it should fail
5. In GL for the request to `https://auth-json-server.zapier.ninja/me`, you'll see the auth header uncensored (`Authorization: basic somethinghere==`)
5. in your app's `package.json`, change the `zapier-platform-core` dependency to `zapier/zapier-platform-core#censor-auth-headers`; `npm i`
8. change the line in `package.json` back to `8.0.1`
8. run `SKIP_NPM_INSTALL=1 zapier push`
4. connect an auth again, use any random string
3. in GL, the request should now have the header properly censored (`Authorization: censored:asdfdfsa:9`)