### PR TITLE
Censor sensitive numbers

### DIFF
--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -44,6 +44,9 @@ const recurseCleanFuncs = (obj, path) => {
 // Recurse a nested object replace all instances of keys->vals in the bank.
 const recurseReplaceBank = (obj, bank = {}) => {
   const replacer = out => {
+    if (typeof out === 'number') {
+      out = String(out);
+    }
     if (typeof out !== 'string') {
       return out;
     }

--- a/src/tools/create-logger.js
+++ b/src/tools/create-logger.js
@@ -108,6 +108,7 @@ const makeSensitiveBank = (event, data) => {
       // keeps short values from spamming censor strings in logs, < 6 chars is not a proper secret
       // see https://github.com/zapier/zapier-platform-core/issues/4#issuecomment-277855071
       if (val && String(val).length > 5) {
+        val = String(val);
         const censored = hashing.snipify(val);
         bank[val] = censored;
         bank[encodeURIComponent(val)] = censored;

--- a/test/logger.js
+++ b/test/logger.js
@@ -245,6 +245,41 @@ describe('logger', () => {
     });
   });
 
+  it('should replace sensitive data that is not a string', () => {
+    const bundle = {
+      authData: {
+        numerical_token: 314159265
+      }
+    };
+    const logger = createlogger({ bundle }, options);
+
+    const data = {
+      response_json: {
+        hello: 314159265
+      },
+      response_content: `{
+        "hello": 314159265
+      }`
+    };
+
+    return logger('test', data).then(response => {
+      response.status.should.eql(200);
+      response.content.json.should.eql({
+        token: options.token,
+        message: 'test',
+        data: {
+          response_json: {
+            hello: ':censored:9:9cb84e8ccc:'
+          },
+          response_content: `{
+        "hello": :censored:9:9cb84e8ccc:
+      }`,
+          log_type: 'console'
+        }
+      });
+    });
+  });
+
   it('should not replace safe log keys', () => {
     const bundle = {
       authData: {


### PR DESCRIPTION
Fixes two problems:

  1. When creating the sensitive bank, we add entries for secrets,
     their URI-encoded value, and their base64-encoded value. For
     numeric secrets (e.g. a bank account id of 8675309), the line
     where we base64-encoded the secret failed because Buffer.from
     won't accept a numeric value.
  2. When replacing values from the sensitive bank, only Strings
     were considered. This still worked for replacing values inside
     of a string (e.g. `Your account number is :censored:`) but not
     as a standalone value in an object (e.g. `{account: 314159}`).

## Testing

1. `zapier init censortest --template=minimal`
2. Add the following lines inside of the `App` definition in `index.js`:

```js
  authentication: {
    type: 'session',
    fields: [
      {
        key: 'topping',
        type: 'string',
        label: 'Topping',
        helpText: 'What is your favorite pizza topping?',
        required: true,
      },
      {
        key: 'account',
        type: 'integer',
        required: false,
        computed: true,
      }
    ],
    test: (z, bundle) => z.request({
      url: 'http://httpbin.org/post',
      method: 'POST',
      headers: {'X-ID': 314159265},
      body: {id: 314159265},
    }).then(resp => resp.json.data),
    connectionLabel: '{{account}}',
    sessionConfig: {
      perform: (z, bundle) => ({account: 314159265})
    },
  },
```

3. `zapier push`
4. [Create an auth](https://zapier.com/app/settings/authorizations)
5. In GL, for the request logs for the POST to `http://httpbin.org/post`, you'll see multiple `null` references logged.
6. In your app's `package.json`, change the `zapier-platform-core` dependency to `zapier/zapier-platform-core#fix-censor-numbers`; `npm i`
7. Change the line in `package.json` back to `8.0.1`
8. Run `SKIP_NPM_INSTALL=1 zapier push`
9. Press the "Test" button for your auth
10. In GL, the `input` data should now have the value `:censored:9:9cb84e8ccc:` properly censored everywhere.