### PR TITLE
Prevent raw curies from being sent in a request. Allow removing empty…

### DIFF
--- a/src/http-middlewares/before/add-query-params.js
+++ b/src/http-middlewares/before/add-query-params.js
@@ -1,21 +1,7 @@
 'use strict';
 
 const querystring = require('querystring');
-
-const isCurlies = /{{.*?}}/g;
-const shouldPruneQueryParam = value =>
-  value === '' ||
-  value === null ||
-  value === undefined ||
-  isCurlies.test(value);
-
-// Mutates the object (it'll be deleted later anyway)
-const pruneMissingQueryParams = params =>
-  Object.keys(params).forEach(param => {
-    if (shouldPruneQueryParam(params[param])) {
-      delete params[param];
-    }
-  });
+const { normalizeEmptyParamField } = require('../../tools/cleaner');
 
 const hasQueryParams = ({ params = {} }) => Object.keys(params).length;
 
@@ -26,9 +12,7 @@ const addQueryParams = req => {
   if (hasQueryParams(req)) {
     const splitter = req.url.includes('?') ? '&' : '?';
 
-    if (req.removeMissingValuesFrom.params) {
-      pruneMissingQueryParams(req.params);
-    }
+    Object.entries(req.params).forEach(normalizeEmptyParamField(req));
 
     const stringifiedParams = querystring.stringify(req.params);
 

--- a/src/http-middlewares/before/add-query-params.js
+++ b/src/http-middlewares/before/add-query-params.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const querystring = require('querystring');
-const { normalizeEmptyParamField } = require('../../tools/cleaner');
+const { normalizeEmptyParamFields } = require('../../tools/cleaner');
 
 const hasQueryParams = ({ params = {} }) => Object.keys(params).length;
 
@@ -12,7 +12,7 @@ const addQueryParams = req => {
   if (hasQueryParams(req)) {
     const splitter = req.url.includes('?') ? '&' : '?';
 
-    Object.entries(req.params).forEach(normalizeEmptyParamField(req));
+    normalizeEmptyParamFields(req);
 
     const stringifiedParams = querystring.stringify(req.params);
 

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -4,7 +4,11 @@ const _ = require('lodash');
 const stream = require('stream');
 const querystring = require('querystring');
 
-const cleaner = require('../../tools/cleaner');
+const {
+  createBundleBank,
+  normalizeEmptyBodyField,
+  recurseReplaceBank
+} = require('../../tools/cleaner');
 const requestMerge = require('../../tools/request-merge');
 const {
   getContentType,
@@ -56,6 +60,8 @@ const coerceBody = req => {
   } else if (Buffer.isBuffer(req.body)) {
     // leave a buffer alone!
   } else if (req.body && !_.isString(req.body)) {
+    Object.entries(req.body).forEach(normalizeEmptyBodyField(req));
+
     // this is a general - popular fallback
     req.body = JSON.stringify(req.body);
 
@@ -120,11 +126,8 @@ const prepareRequest = function(req) {
 
   // replace {{curlies}} in the request
   if (req.replace) {
-    const bank = cleaner.createBundleBank(
-      input._zapier.app,
-      input._zapier.event
-    );
-    req = cleaner.recurseReplaceBank(req, bank);
+    const bank = createBundleBank(input._zapier.app, input._zapier.event);
+    req = recurseReplaceBank(req, bank);
   }
 
   req = coerceBody(req);

--- a/src/http-middlewares/before/prepare-request.js
+++ b/src/http-middlewares/before/prepare-request.js
@@ -6,7 +6,7 @@ const querystring = require('querystring');
 
 const {
   createBundleBank,
-  normalizeEmptyBodyField,
+  normalizeEmptyBodyFields,
   recurseReplaceBank
 } = require('../../tools/cleaner');
 const requestMerge = require('../../tools/request-merge');
@@ -60,7 +60,7 @@ const coerceBody = req => {
   } else if (Buffer.isBuffer(req.body)) {
     // leave a buffer alone!
   } else if (req.body && !_.isString(req.body)) {
-    Object.entries(req.body).forEach(normalizeEmptyBodyField(req));
+    normalizeEmptyBodyFields(req);
 
     // this is a general - popular fallback
     req.body = JSON.stringify(req.body);

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -110,16 +110,16 @@ const createBundleBank = (appRaw, event = {}) => {
 
 const maskOutput = output => _.pick(output, 'results', 'status');
 
-const normalizeEmptyRequestField = (shouldCleanup, field) => req => {
+const normalizeEmptyRequestFields = (shouldCleanup, field, req) => {
   const handleEmpty = req.removeMissingValuesFrom[field]
     ? key => delete req[field][key]
     : key => (req[field][key] = '');
 
-  return ([key, value]) => {
+  Object.entries(req[field]).forEach(([key, value]) => {
     if (shouldCleanup(value)) {
       handleEmpty(key);
     }
-  };
+  });
 };
 
 const isCurlies = /{{.*?}}/;
@@ -129,11 +129,13 @@ const isEmptyQueryParam = value =>
   value === undefined ||
   isCurlies.test(value);
 
-const normalizeEmptyParamField = normalizeEmptyRequestField(
+const normalizeEmptyParamFields = normalizeEmptyRequestFields.bind(
+  null,
   isEmptyQueryParam,
   'params'
 );
-const normalizeEmptyBodyField = normalizeEmptyRequestField(
+const normalizeEmptyBodyFields = normalizeEmptyRequestFields.bind(
+  null,
   v => isCurlies.test(v),
   'body'
 );
@@ -141,8 +143,8 @@ const normalizeEmptyBodyField = normalizeEmptyRequestField(
 module.exports = {
   createBundleBank,
   maskOutput,
-  normalizeEmptyBodyField,
-  normalizeEmptyParamField,
+  normalizeEmptyBodyFields,
+  normalizeEmptyParamFields,
   recurseCleanFuncs,
   recurseReplaceBank
 };

--- a/src/tools/cleaner.js
+++ b/src/tools/cleaner.js
@@ -110,9 +110,39 @@ const createBundleBank = (appRaw, event = {}) => {
 
 const maskOutput = output => _.pick(output, 'results', 'status');
 
+const normalizeEmptyRequestField = (shouldCleanup, field) => req => {
+  const handleEmpty = req.removeMissingValuesFrom[field]
+    ? key => delete req[field][key]
+    : key => (req[field][key] = '');
+
+  return ([key, value]) => {
+    if (shouldCleanup(value)) {
+      handleEmpty(key);
+    }
+  };
+};
+
+const isCurlies = /{{.*?}}/;
+const isEmptyQueryParam = value =>
+  value === '' ||
+  value === null ||
+  value === undefined ||
+  isCurlies.test(value);
+
+const normalizeEmptyParamField = normalizeEmptyRequestField(
+  isEmptyQueryParam,
+  'params'
+);
+const normalizeEmptyBodyField = normalizeEmptyRequestField(
+  v => isCurlies.test(v),
+  'body'
+);
+
 module.exports = {
-  recurseCleanFuncs,
-  recurseReplaceBank,
   createBundleBank,
-  maskOutput
+  maskOutput,
+  normalizeEmptyBodyField,
+  normalizeEmptyParamField,
+  recurseCleanFuncs,
+  recurseReplaceBank
 };


### PR DESCRIPTION
## Ticket
https://zapierorg.atlassian.net/browse/PDE-889 from Issue
 
From issue: https://github.com/zapier/zapier/issues/25928

This PR addresses two issues:
1. Prevent unresolved curlies from being sent in query params or the request body
1. Check if we should prune missing values from the body

A couple considerations, we don't remove unresolved curlies from url path. This might allow something like `https://api.com/resouce/{{bundle.inputData.id}}`

Some [context](https://zapier.slack.com/archives/C5Z9BP4U9/p1558623857027800) from slack 