### PR TITLE
fix regression where env is ignored

### DIFF
--- a/include/zapierwrapper.js
+++ b/include/zapierwrapper.js
@@ -2,10 +2,5 @@
 const path = require('path');
 const zapier = require('zapier-platform-core');
 const appPath = path.resolve(__dirname, 'index.js');
-let opts;
-try {
-  opts = require(appPath).flags;
-} catch (error) {
-  // nothing to see here
-}
-module.exports = { handler: zapier.createAppHandler(appPath, opts) };
+// don't `require(appPath)` out here
+module.exports = { handler: zapier.createAppHandler(appPath) };

--- a/src/tools/create-app-tester.js
+++ b/src/tools/create-app-tester.js
@@ -37,8 +37,7 @@ const promisifyHandler = handler => {
 
 // A shorthand compatible wrapper for testing.
 const createAppTester = (appRaw, { customStoreKey } = {}) => {
-  const opts = appRaw.flags;
-  const handler = createLambdaHandler(appRaw, opts);
+  const handler = createLambdaHandler(appRaw);
   const createHandlerPromise = promisifyHandler(handler);
 
   const randomSeed = genId();

--- a/src/tools/create-lambda-handler.js
+++ b/src/tools/create-lambda-handler.js
@@ -130,14 +130,8 @@ const loadApp = (event, rpc, appRawOrPath) => {
   });
 };
 
-const createLambdaHandler = (appRawOrPath, { skipHttpPatch } = {}) => {
+const createLambdaHandler = appRawOrPath => {
   const handler = (event, context, callback) => {
-    // Adds logging for _all_ kinds of http(s) requests, no matter the library
-    if (!skipHttpPatch) {
-      const httpPatch = createHttpPatch(event);
-      httpPatch(require('http')); // 'https' uses 'http' under the hood
-    }
-
     // Wait for all async events to complete before callback returns.
     // This is not strictly necessary since this is the default now when
     // using the callback; just putting it here to be explicit.
@@ -199,6 +193,13 @@ const createLambdaHandler = (appRawOrPath, { skipHttpPatch } = {}) => {
       return loadApp(event, rpc, appRawOrPath)
         .then(appRaw => {
           const app = createApp(appRaw);
+
+          const { skipHttpPatch } = appRaw.flags || {};
+          // Adds logging for _all_ kinds of http(s) requests, no matter the library
+          if (!skipHttpPatch) {
+            const httpPatch = createHttpPatch(event);
+            httpPatch(require('http')); // 'https' uses 'http' under the hood
+          }
 
           // TODO: Avoid calling prepareApp(appRaw) repeatedly here as createApp()
           // already calls prepareApp() but just doesn't return it.


### PR DESCRIPTION
Ok! So this fixes https://github.com/zapier/zapier/issues/26273. The root issue was that the early `require(appPath)`. Imagine you have the following:

```js
// app/index.js
module.exports = {
  // ... whatever
  url: `${process.env.BASE_URL}/oauth`,
}
```

when you `require('./app')`, `process.env.BASE_URL` is evaluated. The only problem is, the `env` being passed into lambda from the server isn't merged into `process.env` until [this line](https://github.com/zapier/zapier-platform-core/compare/fix-missing-env?expand=1#diff-b1d9d87090de25e8dcacf07d34e2e495R189), so `app.url` is `undefined/oauth`. When it's required again as part of `loadApp` further down, the result is cached. So even though `process.env.BASE_URL` exists, the url is wrong.

I read carefully through everything the http patch does and moving it further into that method should have no ill effects (since nothing between its original and new position can use the `http` module). All the tests are passing as well. I also tested locally and the current env pops up as expected.

I tried the following in `loadApp`, but weirdly, it didn't work. I had sunk enough time into this as is, so I didn't dig much further after confirming the fix itself.

```js
delete require.cache[require.resolve(appRawOrPath)]; // always get a fresh copy of the app
return resolve(require(appRawOrPath));
```
