### PR TITLE
Bump legacy-scripting-runner version to 3.1.0

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -12,6 +12,6 @@
   },
   "dependencies": {
     "zapier-platform-core": "CORE_PLATFORM_VERSION",
-    "zapier-platform-legacy-scripting-runner": "3.0.0"
+    "zapier-platform-legacy-scripting-runner": "3.1.0"
   }
 }


### PR DESCRIPTION
We need the bug fixes in 3.1.0 for converted Web Builder apps.